### PR TITLE
Always return unique list of dylibs and clarify comments

### DIFF
--- a/lib/macho/fat_file.rb
+++ b/lib/macho/fat_file.rb
@@ -131,7 +131,9 @@ module MachO
 		# All shared libraries linked to the file's Mach-Os.
 		# @return [Array<String>] an array of all shared libraries
 		def linked_dylibs
-			# can machos inside fat binaries have different dylibs?
+			# Individual architectures in a fat binary can link to different subsets
+			# of libraries, but at this point we want to have the full picture, i.e.
+			# the union of all libraries used by all architectures.
 			machos.flat_map(&:linked_dylibs).uniq
 		end
 

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -215,7 +215,11 @@ module MachO
 		# All shared libraries linked to the Mach-O.
 		# @return [Array<String>] an array of all shared libraries
 		def linked_dylibs
-			dylib_load_commands.map(&:name).map(&:to_s)
+			# Some linkers produce multiple `LC_LOAD_DYLIB` load commands for the same
+			# library, but at this point we're really only interested in a list of
+			# unique libraries this Mach-O file links to, thus: `uniq`. (This is also
+			# for consistency with `FatFile` that merges this list across all archs.)
+			dylib_load_commands.map(&:name).map(&:to_s).uniq
 		end
 
 		# Changes the shared library `old_name` to `new_name`


### PR DESCRIPTION
Here's an example of a non-fat binary that links multiple times to the same dylib:

- `$(brew --cellar)/go/1.5.3/libexec/bin/godoc`

Here are some examples of fat binaries provided by the system (on OS X 10.11.3) that link to different subsets of libraries depending on architecture (differences can be inspected with `otool -arch <arch> -L <file>`, where `<arch>` is one of `i386`, `x86_64`):

- `/System/Library/CoreServices/Photo Library Migration Utility.app/Contents/Frameworks/iLifeSlideshow.framework/Versions/A/iLifeSlideshow`
- `/System/Library/PrivateFrameworks/iTunesAccess.framework/Versions/A/iTunesAccess`
- `/System/Library/Video/Plug-Ins/AppleProResCodec.bundle/Contents/MacOS/AppleProResCodec`