### PR TITLE
Testing: Add skeleton for new benchmarking tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 group :test do
 	gem 'rake'
 	gem 'minitest'
-	gem 'simplecov'
+	gem 'benchmark-ips'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "rake/testtask"
+require_relative "test/bench"
 
 Rake::TestTask.new do |t|
 	t.libs << 'test'
@@ -6,3 +7,8 @@ end
 
 desc "Run tests"
 task :default => :test
+
+desc "Run benchmarks"
+task :bench do
+	RubyMachOBenchmark.new.run
+end

--- a/test/bench.rb
+++ b/test/bench.rb
@@ -1,0 +1,89 @@
+require "#{File.dirname(__FILE__)}/helpers"
+require "benchmark/ips"
+
+class RubyMachOBenchmark
+	include Helpers
+
+	def run
+		unless installed?("otool") && installed?("install_name_tool")
+			puts "otool and install_name_tool are required to run benchmarks."
+			return
+		end
+
+		bench_get_id
+		bench_get_dylibs
+		bench_set_id
+		bench_set_dylibs
+	end
+
+	def bench_get_id
+		Benchmark.ips do |bm|
+			bm.report("otool_get_id") do
+				libs = `otool -L #{TEST_DYLIB}`.split("\n")
+				libs.shift
+				libs.shift[OTOOL_RX, 1]
+			end
+
+			bm.report("ruby_get_id") do
+				MachO.open(TEST_DYLIB).dylib_id
+			end
+		end
+	end
+
+	def bench_get_dylibs
+		Benchmark.ips do |bm|
+			bm.report("otool_get_dylib") do
+				libs = `otool -L #{TEST_DYLIB}`.split("\n")
+				libs.shift(2)
+				libs.map! { |lib| lib[OTOOL_RX, 1] }.compact!
+			end
+
+			bm.report("ruby_get_dylib") do
+				MachO::Tools.dylibs(TEST_DYLIB)
+			end
+		end
+	end
+
+	def bench_set_id
+		i = 0
+		benchfile = "#{TEST_DYLIB}.bench"
+		FileUtils.cp("#{TEST_DYLIB}", benchfile)
+
+		Benchmark.ips do |bm|
+			bm.report("int_set_id") do
+				`install_name_tool -id #{i += 1} #{benchfile}`
+			end
+
+			i = 0
+
+			bm.report("ruby_set_id") do
+				MachO::Tools.change_dylib_id(benchfile, "#{i += 1}")
+			end
+		end
+	ensure
+		delete_if_exists(benchfile)
+	end
+
+	def bench_set_dylibs
+		i = 0
+		benchfile = "#{TEST_DYLIB}.bench"
+		FileUtils.cp("#{TEST_DYLIB}", benchfile)
+
+		Benchmark.ips do |bm|
+			MachO::Tools.change_install_name(benchfile, "/usr/lib/libSystem.B.dylib", "0")
+
+			bm.report("int_set_dylib") do
+				`install_name_tool -change #{i} #{i += 1} #{benchfile}`
+			end
+
+			MachO::Tools.change_install_name(benchfile, "#{i}", "0")
+			i = 0
+
+			bm.report("ruby_set_dylib") do
+				MachO::Tools.change_install_name(benchfile, "#{i}", "#{i += 1}")
+			end
+		end
+	ensure
+		delete_if_exists(benchfile)
+	end
+end

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -1,7 +1,6 @@
+require_relative "../lib/macho"
 require "digest/sha1"
-require "simplecov"
-
-SimpleCov.start
+require "fileutils"
 
 module Helpers
 	TEST_OBJ = "test/bin/hello.o"
@@ -15,6 +14,12 @@ module Helpers
 	TEST_FAT_DYLIB = "test/bin/libfathello.dylib"
 	TEST_FAT_EXTRA_DYLIB = "test/bin/libfatextrahello.dylib"
 	TEST_FAT_BUNDLE = "test/bin/fathellobundle.so"
+
+	OTOOL_RX = /\t(.*) \(compatibility version (?:\d+\.)*\d+, current version (?:\d+\.)*\d+\)/
+
+	def installed?(util)
+		!`which #{util}`.empty?
+	end
 
 	def delete_if_exists(file)
 		if File.exist?(file)


### PR DESCRIPTION
Add test_bench.rb, which will contain benchmarking tests
for both ruby-macho and otool/install_name_tool.

Add benchmark/ips as a dependency to conduct the forthcoming
benchmarks.

Add Helpers.installed? to selectively run benchmark tests
if external utilities are not available.

cc @UniqMartin, @xu-cheng 
ref #7 

- [x] Stub out benchmarks
- [x] Fill in `ruby-macho` benchmarks
- [x] Fill in `otool`/`install_name_tool` benchmarks