### PR TITLE
MagicError: don't fail if magic number is nil

### DIFF
--- a/lib/macho/exceptions.rb
+++ b/lib/macho/exceptions.rb
@@ -5,9 +5,13 @@ module MachO
 
   # Raised when a file's magic bytes are not valid Mach-O magic.
   class MagicError < MachOError
-    # @param num [Fixnum] the unknown number
+    # @param num [Fixnum, nil] the unknown number or nil if no number was read
     def initialize(num)
-      super "Unrecognized Mach-O magic: 0x#{"%02x" % num}"
+      if num
+        super "Unrecognized Mach-O magic: 0x#{"%02x" % num}"
+      else
+        super "Unrecognized Mach-O magic: file too short"
+      end
     end
   end
 


### PR DESCRIPTION
If the read file is too short (or empty), `magic` will be nil and the `MagicError` exception itself will throw an exception because nil cannot be formatted as an integer. Provide a more appropriate exception message in those cases.

@woodruffw I tagged this as `in progress` because I'm not sure this is a good fix for the issue and would appreciate your feedback. Should we create a separate superclass for exceptions that don't indicate an error in parsing, but simply the fact that the file is neither a Mach-O nor a fat binary? Possible reasons might be:

- It doesn't have the expected magic number.
- It's too short to accommodate the headers, so it cannot be a Mach-O/fat binary.
- It does have the expected magic number, but other sanity checks fail. (Can happen if the magic number is shared by other file formats, too.)

That might simplify handling/suppressing these exceptions where appropriate while still getting useful errors if there are real problems.