### PR TITLE
FatFile/MachOFile: avoid some code duplication

### DIFF
--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -235,7 +235,9 @@ module MachO
 				flags)
 			@magic = magic
 			@cputype = cputype
-			@cpusubtype = cpusubtype
+			# For now we're not interested in additional capability bits also to be
+			# found in the `cpusubtype` field. We only care about the CPU sub-type.
+			@cpusubtype = cpusubtype & ~CPU_SUBTYPE_MASK
 			@filetype = filetype
 			@ncmds = ncmds
 			@sizeofcmds = sizeofcmds

--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -162,7 +162,7 @@ module MachO
 		# @return [Fixnum] the number of fat architecture structures following the header
 		attr_reader :nfat_arch
 
-		FORMAT = "VV"
+		FORMAT = "N2" # always big-endian
 		SIZEOF = 8
 
 		# @api private
@@ -191,7 +191,7 @@ module MachO
 		# @return [Fixnum] the alignment, as a power of 2
 		attr_reader :align
 
-		FORMAT = "VVVVV"
+		FORMAT = "N5" # always big-endian
 		SIZEOF = 20
 
 		# @api private


### PR DESCRIPTION
The commits go into a bit more detail, but the idea is to rely more on `MachOStructure.new_from_bin` for handling the structs instead of replicating that logic (and basically ignoring `FORMAT`), thus making it more likely to create inconsistencies.

*For full disclosure where I hope this leads to:* This is one (of possibly several) preparatory PRs to pave the way for full endian awareness in the code. In a local branch I have already hacked together everything so that the code is able to correctly read 32/64-bit x86/PPC/ARM binaries. (I cross-checked with `otool` to a reasonable extent and let it crunch through most of my system disk.)