### PR TITLE
1.8.7 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,5 @@ rvm:
     - 1.8.7
     - 1.9.3
     - 2.0.0
-matrix:
-    allow_failures:
-        - rvm: 1.8.7
 cache: bundler
 sudo: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
+$:.unshift "#{File.dirname(__FILE__)}/lib"
+$:.unshift "#{File.dirname(__FILE__)}/test"
 require "rake/testtask"
-require_relative "test/bench"
+require "bench"
 
 Rake::TestTask.new do |t|
 	t.libs << 'test'

--- a/lib/macho/fat_file.rb
+++ b/lib/macho/fat_file.rb
@@ -134,7 +134,7 @@ module MachO
 			# Individual architectures in a fat binary can link to different subsets
 			# of libraries, but at this point we want to have the full picture, i.e.
 			# the union of all libraries used by all architectures.
-			machos.flat_map(&:linked_dylibs).uniq
+			machos.map(&:linked_dylibs).flatten.uniq
 		end
 
 		# Changes all dependent shared library install names from `old_name` to `new_name`.

--- a/test/bench.rb
+++ b/test/bench.rb
@@ -1,4 +1,4 @@
-require "#{File.dirname(__FILE__)}/helpers"
+require "helpers"
 require "benchmark/ips"
 
 class RubyMachOBenchmark

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -1,4 +1,4 @@
-require_relative "../lib/macho"
+require "macho"
 require "digest/sha1"
 require "fileutils"
 

--- a/test/test_fat.rb
+++ b/test/test_fat.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "#{File.dirname(__FILE__)}/helpers"
+require "helpers"
 require "macho"
 
 class FatFileTest < Minitest::Test

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "#{File.dirname(__FILE__)}/helpers"
+require "helpers"
 require "macho"
 
 class MachOFileTest < Minitest::Test

--- a/test/test_open.rb
+++ b/test/test_open.rb
@@ -1,6 +1,6 @@
-require 'minitest/autorun'
-require "#{File.dirname(__FILE__)}/helpers"
-require 'macho'
+require "minitest/autorun"
+require "helpers"
+require "macho"
 
 class MachOOpenTest < Minitest::Test
 	include Helpers

--- a/test/test_tools.rb
+++ b/test/test_tools.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "#{File.dirname(__FILE__)}/helpers"
+require "helpers"
 require "macho"
 
 class MachOToolsTest < Minitest::Test


### PR DESCRIPTION
Tasks:

- [x] Get the test suite itself compatible with 1.8.7.
- [x] Make `ruby-macho` itself compatible with 1.8.7.