### PR TITLE
Maintenance: Replace tab indentation with two-space.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :test do
-	gem 'rake'
-	gem 'minitest'
-	gem 'benchmark-ips'
+  gem 'rake'
+  gem 'minitest'
+  gem 'benchmark-ips'
 end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ file.filetype # => "MH_EXECUTE"
 
 # get all load commands in the file and print their offsets:
 file.load_commands.each do |lc|
-	puts "#{lc}: offset #{lc.offset}, size: #{lc.cmdsize}"
+  puts "#{lc}: offset #{lc.offset}, size: #{lc.cmdsize}"
 end
 
 # access a specific load command

--- a/ruby-macho.gemspec
+++ b/ruby-macho.gemspec
@@ -1,13 +1,13 @@
 require "#{File.dirname(__FILE__)}/lib/macho"
 
 Gem::Specification.new do |s|
-	s.name = 'ruby-macho'
-	s.version = MachO::VERSION
-	s.summary = 'ruby-macho - Mach-O file analyzer.'
-	s.description = 'A library for viewing and manipulating Mach-O files in Ruby.'
-	s.authors = ['William Woodruff']
-	s.email = 'william@tuffbizz.com'
-	s.files = Dir['LICENSE', 'README.md', '.yardopts', 'lib/**/*']
-	s.homepage = 'https://github.com/Homebrew/ruby-macho'
-	s.license = 'MIT'
+  s.name = 'ruby-macho'
+  s.version = MachO::VERSION
+  s.summary = 'ruby-macho - Mach-O file analyzer.'
+  s.description = 'A library for viewing and manipulating Mach-O files in Ruby.'
+  s.authors = ['William Woodruff']
+  s.email = 'william@tuffbizz.com'
+  s.files = Dir['LICENSE', 'README.md', '.yardopts', 'lib/**/*']
+  s.homepage = 'https://github.com/Homebrew/ruby-macho'
+  s.license = 'MIT'
 end

--- a/test/src/hello.c
+++ b/test/src/hello.c
@@ -2,5 +2,5 @@
 
 int main(int argc, char** argv)
 {
-	printf("Hello, World!\n");
+  printf("Hello, World!\n");
 }

--- a/test/src/libhello.c
+++ b/test/src/libhello.c
@@ -4,5 +4,5 @@ void hello(void);
 
 void hello(void)
 {
-	printf("Hello, World!\n");
+  printf("Hello, World!\n");
 }


### PR DESCRIPTION
Changes indentation in non-ruby (i.e., not ending in .rb)
repo files.