### PR TITLE
Error Handling: Add NotAMachOError for edge cases.

### DIFF
--- a/lib/macho/exceptions.rb
+++ b/lib/macho/exceptions.rb
@@ -3,11 +3,33 @@ module MachO
   class MachOError < RuntimeError
   end
 
+  # Raised when a file is not a Mach-O.
+  class NotAMachOError < MachOError
+    # @param error [String] the error in question
+    def initialize(error)
+      super error
+    end
+  end
+
+  # Raised when a file is too short to be a valid Mach-O file.
+  class TruncatedFileError < NotAMachOError
+    def initialize
+      super "File is too short to be a valid Mach-O"
+    end
+  end
+
   # Raised when a file's magic bytes are not valid Mach-O magic.
-  class MagicError < MachOError
+  class MagicError < NotAMachOError
     # @param num [Fixnum] the unknown number
     def initialize(num)
       super "Unrecognized Mach-O magic: 0x#{"%02x" % num}"
+    end
+  end
+
+  # Raised when a file is a Java classfile instead of a fat Mach-O.
+  class JavaClassFileError < NotAMachOError
+    def initialize
+      super "File is a Java class file"
     end
   end
 

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -314,8 +314,12 @@ module MachO
     # The file's Mach-O header structure.
     # @return [MachO::MachHeader] if the Mach-O is 32-bit
     # @return [MachO::MachHeader64] if the Mach-O is 64-bit
+    # @raise [MachO::TruncatedFileError] if the file is too small to have a valid header
     # @private
     def get_mach_header
+      # the smallest Mach-O header is 28 bytes
+      raise TruncatedFileError.new if @raw_data.size < 28
+
       magic = get_and_check_magic
       mh_klass = MachO.magic32?(magic) ? MachHeader : MachHeader64
       mh = mh_klass.new_from_bin(@raw_data[0, mh_klass.bytesize])

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -1,6 +1,7 @@
 require "macho"
 require "digest/sha1"
 require "fileutils"
+require "tempfile"
 
 module Helpers
   TEST_OBJ = "test/bin/hello.o"
@@ -43,5 +44,13 @@ module Helpers
     checks.delete(except)
 
     checks
+  end
+
+  def tempfile_with_data(filename, data)
+    Tempfile.open(filename) do |file|
+      file.write(data)
+      file.rewind
+      yield file
+    end
   end
 end

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -5,6 +5,22 @@ require "macho"
 class MachOFileTest < Minitest::Test
   include Helpers
 
+  def test_empty_file
+    tempfile_with_data("empty_file", "") do |empty_file|
+      assert_raises MachO::TruncatedFileError do
+        MachO::MachOFile.new(empty_file.path)
+      end
+    end
+  end
+
+  def test_truncated_file
+    tempfile_with_data("truncated_file", "\xFE\xED\xFA\xCE\x00\x00") do |truncated_file|
+      assert_raises MachO::TruncatedFileError do
+        MachO::MachOFile.new(truncated_file.path)
+      end
+    end
+  end
+
   def test_load_commands
     file = MachO::MachOFile.new(TEST_EXE)
 


### PR DESCRIPTION
There are two edge cases early-on in the parsing process:
files too small to have a valid magic number and files
with valid magic but invalid contents (most notably, Java
classfiles).

The NotAMachOError class covers both of these cases, and is raised
in FatFile#get_fat_header and MachOFile#get_and_check_magic.

cc @UniqMartin 