### PR TITLE
MachOFile#set_lc_str_in_cmd: Fix Ruby 1.8.7 bug 

### DIFF
--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -458,12 +458,12 @@ module MachO
       # calculate the low file offset (offset to first section data)
       segments.each do |seg|
         sections(seg).each do |sect|
-          if sect.size != 0 && !sect.flag?(:S_ZEROFILL) &&
-              !sect.flag?(:S_THREAD_LOCAL_ZEROFILL) &&
-              sect.offset < low_fileoff
+          next if sect.size == 0
+          next if sect.flag?(:S_ZEROFILL)
+          next if sect.flag?(:S_THREAD_LOCAL_ZEROFILL)
+          next unless sect.offset < low_fileoff
 
-            low_fileoff = sect.offset
-          end
+          low_fileoff = sect.offset
         end
       end
 

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -453,7 +453,7 @@ module MachO
       new_size = cmd.class.bytesize + new_str.size
       new_sizeofcmds += new_size - cmd.cmdsize
 
-      low_fileoff = 2**64 # ULLONGMAX
+      low_fileoff = @raw_data.size
 
       # calculate the low file offset (offset to first section data)
       segments.each do |seg|


### PR DESCRIPTION
With Ruby from `homebrew/versions/ruby187` (1.8.7-p374) on OS X 10.11.3 `2**64` unfortunately yields `0` instead of the correct value. Setting this to the size of the raw data works around that issue and should work equally well, as the size of the entire Mach-O binary should be a sane upper limit for this.

In practice, the size of a Mach-O binary is already limited to 32 bits because the elements of `FatArch` and many offsets used in load commands are only 32 bits wide.

Without this fix, running the test suite failed for me for all tests that modify a Mach-O binary. This fix, even if Ruby is at fault, is important because we use the same version of Ruby in our 10.9 CI.

(I also snuck in a stylistic change in the second commit.)