### PR TITLE
Testing: Simplify running the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,16 @@
-doc/
-.yardoc/
-coverage/
-*.dylib
-*.so
-*.a
-*.bin
-*.gem
-!test/bin/*
-Gemfile.lock
+# Documentation.
+/.yardoc/
+/doc/
+
+# Gems for redistribution.
+/ruby-macho-*.gem
+
+# Testing.
+/coverage/
+
+# Build results for test cases before they are selectively moved to '/test/bin'.
+/test/src/*.a
+/test/src/*.bin
+/test/src/*.dylib
+/test/src/*.o
+/test/src/*.so

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 /ruby-macho-*.gem
 
 # Testing.
+/.bundle/
 /coverage/
+/vendor/bundle/
 
 # Build results for test cases before they are selectively moved to '/test/bin'.
 /test/src/*.a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    benchmark-ips (2.5.0)
+    minitest (5.8.4)
+    rake (10.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  benchmark-ips
+  minitest
+  rake
+
+BUNDLED WITH
+   1.11.2

--- a/run-tests
+++ b/run-tests
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+ensure() {
+  "$@" \
+    || die "Failed to run '$*'. Aborting."
+}
+
+# Make sure we're in the repository root.
+ensure cd "${0%/*}"
+
+# Check that Bundler is available.
+which bundle > /dev/null 2>&1 \
+  || die "Failed to find 'bundle' executable in PATH."
+
+# Setup required Gems for testing.
+echo ">> Checking if required Gems are installed and installing missing Gems."
+if ! bundle check ; then
+  ensure bundle install --path vendor/bundle
+fi
+echo
+
+# Run the test suite.
+echo ">> Running test suite."
+bundle exec rake test
+result="$?"
+echo
+
+# Be done and return result of test suite.
+echo ">> Done."
+exit "$result"


### PR DESCRIPTION
While testing locally with a bunch of different Rubies I found it quite cumbersome to set everything up. The result is `run-tests` which for me simplifies things down to a `with-ruby 1.8 ./run-tests`. As a kind of precondition I felt compelled to re-organize `.gitignore` and sort out the `Gemfile.lock` situation. (I hope I haven't missed anything by moving around and anchoring the ignore rules.)

@woodruffw Not sure what your local setup looks like, so I'm not sure if I'm only doing myself a favor and cluttering up your repository root or if my script is useful enough to occupy that spot.