### PR TITLE
Use symbols to represent filetypes instead of strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ executables, dynamic libraries, and so forth.
 
 ### Documentation
 
+**Important**: ruby-macho does not have a stable API (yet). Use it with this
+in mind.
+
 Full documentation is available on [RubyDoc](http://www.rubydoc.info/gems/ruby-macho/).
 
 A quick example of what ruby-macho can do:
@@ -23,8 +26,8 @@ require 'macho'
 
 file = MachO::MachOFile.new("/path/to/my/binary")
 
-# get the file's type (MH_OBJECT, MH_DYLIB, MH_EXECUTE, etc)
-file.filetype # => "MH_EXECUTE"
+# get the file's type (object, dynamic lib, executable, etc)
+file.filetype # => :execute
 
 # get all load commands in the file and print their offsets:
 file.load_commands.each do |lc|
@@ -32,7 +35,7 @@ file.load_commands.each do |lc|
 end
 
 # access a specific load command
-lc_vers = file['LC_VERSION_MIN_MACOSX'].first
+lc_vers = file[:LC_VERSION_MIN_MACOSX].first
 puts lc_vers.version_string # => "10.10.0"
 ```
 

--- a/lib/macho/fat_file.rb
+++ b/lib/macho/fat_file.rb
@@ -115,7 +115,7 @@ module MachO
     end
 
     # The file's type. Assumed to be the same for every Mach-O within.
-    # @return [String] the filetype
+    # @return [Symbol] the filetype
     def filetype
       machos.first.filetype
     end

--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -312,20 +312,20 @@ module MachO
   # x86_64 kexts
   MH_KEXT_BUNDLE = 0xb
 
-  # association of filetypes to string representations
+  # association of filetypes to Symbol representations
   # @api private
   MH_FILETYPES = {
-    MH_OBJECT => "MH_OBJECT",
-    MH_EXECUTE => "MH_EXECUTE",
-    MH_FVMLIB => "MH_FVMLIB",
-    MH_CORE => "MH_CORE",
-    MH_PRELOAD => "MH_PRELOAD",
-    MH_DYLIB => "MH_DYLIB",
-    MH_DYLINKER => "MH_DYLINKER",
-    MH_BUNDLE => "MH_BUNDLE",
-    MH_DYLIB_STUB => "MH_DYLIB_STUB",
-    MH_DSYM => "MH_DSYM",
-    MH_KEXT_BUNDLE => "MH_KEXT_BUNDLE"
+    MH_OBJECT => :object,
+    MH_EXECUTE => :execute,
+    MH_FVMLIB => :fvmlib,
+    MH_CORE => :core,
+    MH_PRELOAD => :preload,
+    MH_DYLIB => :dylib,
+    MH_DYLINKER => :dylinker,
+    MH_BUNDLE => :bundle,
+    MH_DYLIB_STUB => :dylib_stub,
+    MH_DSYM => :dsym,
+    MH_KEXT_BUNDLE => :kext_bundle,
   }
 
   # association of mach header flag symbols to values

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -124,7 +124,7 @@ module MachO
       MH_MAGICS[magic]
     end
 
-    # @return [String] a string representation of the Mach-O's filetype
+    # @return [Symbol] a string representation of the Mach-O's filetype
     def filetype
       MH_FILETYPES[header.filetype]
     end

--- a/test/test_fat.rb
+++ b/test/test_fat.rb
@@ -104,7 +104,7 @@ class FatFileTest < Minitest::Test
 
       assert_kind_of Fixnum, file.magic
       assert_kind_of String, file.magic_string
-      assert_kind_of String, file.filetype
+      assert_kind_of Symbol, file.filetype
     end
   end
 
@@ -119,7 +119,7 @@ class FatFileTest < Minitest::Test
         refute file.send(check)
       end
 
-      assert_equal "MH_OBJECT", file.filetype
+      assert_equal :object, file.filetype
     end
   end
 
@@ -134,7 +134,7 @@ class FatFileTest < Minitest::Test
         refute file.send(check)
       end
 
-      assert_equal "MH_EXECUTE", file.filetype
+      assert_equal :execute, file.filetype
     end
   end
 
@@ -149,7 +149,7 @@ class FatFileTest < Minitest::Test
         refute file.send(check)
       end
 
-      assert_equal "MH_DYLIB", file.filetype
+      assert_equal :dylib, file.filetype
     end
   end
 
@@ -202,7 +202,7 @@ class FatFileTest < Minitest::Test
         refute file.send(check)
       end
 
-      assert_equal "MH_BUNDLE", file.filetype
+      assert_equal :bundle, file.filetype
     end
   end
 

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -130,7 +130,7 @@ class MachOFileTest < Minitest::Test
 
       assert_kind_of Fixnum, file.magic
       assert_kind_of String, file.magic_string
-      assert_kind_of String, file.filetype
+      assert_kind_of Symbol, file.filetype
       assert_kind_of Symbol, file.cputype
       assert_kind_of Symbol, file.cpusubtype
       assert_kind_of Fixnum, file.ncmds
@@ -153,7 +153,7 @@ class MachOFileTest < Minitest::Test
         refute file.send(check)
       end
 
-      assert_equal "MH_OBJECT", file.filetype
+      assert_equal :object, file.filetype
 
       # it's not a dylib, so it has no dylib id
       assert_nil file.dylib_id
@@ -171,7 +171,7 @@ class MachOFileTest < Minitest::Test
         refute file.send(check)
       end
 
-      assert_equal "MH_EXECUTE", file.filetype
+      assert_equal :execute, file.filetype
 
       # it's not a dylib, so it has no dylib id
       assert_nil file.dylib_id
@@ -189,7 +189,7 @@ class MachOFileTest < Minitest::Test
         refute file.send(check)
       end
 
-      assert_equal "MH_DYLIB", file.filetype
+      assert_equal :dylib, file.filetype
 
       # it's a dylib, so it *must* have a dylib id
       assert file.dylib_id
@@ -241,7 +241,7 @@ class MachOFileTest < Minitest::Test
         refute file.send(check)
       end
 
-      assert_equal "MH_BUNDLE", file.filetype
+      assert_equal :bundle, file.filetype
 
       # it's not a dylib, so it has no dylib id
       assert_nil file.dylib_id


### PR DESCRIPTION
Low priority, just a nice-to-have in a future release.

cc @UniqMartin 
ref https://github.com/Homebrew/brew/pull/378#issuecomment-226939348