### PR TITLE
Make endianness an attribute of all LCs.

### DIFF
--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -1,4 +1,5 @@
 require "#{File.dirname(__FILE__)}/macho/structure"
+require "#{File.dirname(__FILE__)}/macho/view"
 require "#{File.dirname(__FILE__)}/macho/headers"
 require "#{File.dirname(__FILE__)}/macho/load_commands"
 require "#{File.dirname(__FILE__)}/macho/sections"

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -395,7 +395,8 @@ module MachO
         # why do I do this? i don't like declaring constants below
         # classes, and i need them to resolve...
         klass = MachO.const_get "#{LC_STRUCTURES[cmd_sym]}"
-        command = klass.new_from_bin(@raw_data, endianness, offset, @raw_data.slice(offset, klass.bytesize))
+        view = MachOView.new(@raw_data, endianness, offset)
+        command = klass.new_from_bin(view)
 
         load_commands << command
         offset += command.cmdsize

--- a/lib/macho/structure.rb
+++ b/lib/macho/structure.rb
@@ -13,7 +13,7 @@ module MachO
       self::SIZEOF
     end
 
-    # @param endianness [Symbol] either :big or :little
+    # @param endianness [Symbol] either `:big` or `:little`
     # @param bin [String] the string to be unpacked into the new structure
     # @return [MachO::MachOStructure] a new MachOStructure initialized with `bin`
     # @api private
@@ -27,7 +27,7 @@ module MachO
 
     # Convert an abstract (native-endian) String#unpack format to big or little.
     # @param format [String] the format string being converted
-    # @param endianness [Symbol] either :big or :little
+    # @param endianness [Symbol] either `:big` or `:little`
     # @return [String] the converted string
     # @api private
     def self.specialize_format(format, endianness)

--- a/lib/macho/view.rb
+++ b/lib/macho/view.rb
@@ -1,0 +1,23 @@
+module MachO
+  # A representation of some unspecified Mach-O data.
+  class MachOView
+    # @return [String] the raw Mach-O data
+    attr_reader :raw_data
+
+    # @return [Symbol] the endianness of the data (`:big` or `:little`)
+    attr_reader :endianness
+
+    # @return [Fixnum] the offset of the relevant data (in {#raw_data})
+    attr_reader :offset
+
+    # Creates a new MachOView.
+    # @param raw_data [String] the raw Mach-O data
+    # @param endianness [Symbol] the endianness of the data
+    # @param offset [Fixnum] the offset of the relevant data
+    def initialize(raw_data, endianness, offset)
+      @raw_data = raw_data
+      @endianness = endianness
+      @offset = offset
+    end
+  end
+end


### PR DESCRIPTION
This was an oversight on my part, but we're going to need `endianness` in a good number
of load commands in order to extract things like symbol/hint tables in an encapsulated fashion (i.e., not returning flow back to the main `MachOFile`/`FatFile` object every time we need data relevant to a LC).

Once it's in, I can open PRs for my branches that implement the tables/internal structures relevant to various LCs.

cc @UniqMartin 
