### PR TITLE
Add direct two-level hints table access.

### DIFF
--- a/lib/macho/fat_file.rb
+++ b/lib/macho/fat_file.rb
@@ -218,8 +218,8 @@ module MachO
 
       fh = FatHeader.new_from_bin(:big, @raw_data[0, FatHeader.bytesize])
 
-      raise MagicError.new(fh.magic) unless MachO.magic?(fh.magic)
-      raise MachOBinaryError.new unless MachO.fat_magic?(fh.magic)
+      raise MagicError.new(fh.magic) unless Utils.magic?(fh.magic)
+      raise MachOBinaryError.new unless Utils.fat_magic?(fh.magic)
 
       # Rationale: Java classfiles have the same magic as big-endian fat
       # Mach-Os. Classfiles encode their version at the same offset as

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -167,7 +167,7 @@ module MachO
     # @api private
     def self.new_from_bin(view)
       bin = view.raw_data.slice(view.offset, bytesize)
-      format = specialize_format(self::FORMAT, view.endianness)
+      format = Utils.specialize_format(self::FORMAT, view.endianness)
 
       self.new(view, *bin.unpack(format))
     end
@@ -758,9 +758,9 @@ module MachO
       # @param nhints [Fixnum] the number of two-level hints in the table
       # @api private
       def initialize(view, htoffset, nhints)
-        format = (view.endianness == :little) ? "V<" : "V>"
-        raw_table = view.raw_data.slice((htoffset...(htoffset + (nhints * 4))))
-        blobs = raw_table.unpack(format * nhints)
+        format = Utils.specialize_format("L=#{nhints}", view.endianness)
+        raw_table = view.raw_data[htoffset, nhints * 4]
+        blobs = raw_table.unpack(format)
 
         @hints = blobs.map { |b| TwolevelHint.new(b) }
       end
@@ -776,8 +776,8 @@ module MachO
         # @param blob [Fixnum] the 32-bit number containing the lookup hint
         # @api private
         def initialize(blob)
-          @isub_image = (blob >> 24)
-          @itoc = (blob & ((1 << 24) - 1))
+          @isub_image = blob >> 24
+          @itoc = blob & 0x00FFFFFF
         end
       end
     end

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -56,12 +56,12 @@ module MachO
 
     # @return [Boolean] true if the Mach-O has 32-bit magic, false otherwise
     def magic32?
-      MachO.magic32?(header.magic)
+      Utils.magic32?(header.magic)
     end
 
     # @return [Boolean] true if the Mach-O has 64-bit magic, false otherwise
     def magic64?
-      MachO.magic64?(header.magic)
+      Utils.magic64?(header.magic)
     end
 
     # @return [Boolean] true if the file is of type `MH_OBJECT`, false otherwise
@@ -326,7 +326,7 @@ module MachO
       raise TruncatedFileError.new if @raw_data.size < 28
 
       magic = get_and_check_magic
-      mh_klass = MachO.magic32?(magic) ? MachHeader : MachHeader64
+      mh_klass = Utils.magic32?(magic) ? MachHeader : MachHeader64
       mh = mh_klass.new_from_bin(endianness, @raw_data[0, mh_klass.bytesize])
 
       check_cputype(mh.cputype)
@@ -344,10 +344,10 @@ module MachO
     def get_and_check_magic
       magic = @raw_data[0..3].unpack("N").first
 
-      raise MagicError.new(magic) unless MachO.magic?(magic)
-      raise FatBinaryError.new if MachO.fat_magic?(magic)
+      raise MagicError.new(magic) unless Utils.magic?(magic)
+      raise FatBinaryError.new if Utils.fat_magic?(magic)
 
-      @endianness = MachO.little_magic?(magic) ? :little : :big
+      @endianness = Utils.little_magic?(magic) ? :little : :big
 
       magic
     end
@@ -453,8 +453,8 @@ module MachO
       old_str = old_str.dup
       new_str = new_str.dup
 
-      old_pad = MachO.round(old_str.size + 1, cmd_round) - old_str.size
-      new_pad = MachO.round(new_str.size + 1, cmd_round) - new_str.size
+      old_pad = Utils.round(old_str.size + 1, cmd_round) - old_str.size
+      new_pad = Utils.round(new_str.size + 1, cmd_round) - new_str.size
 
       # pad the old and new IDs with null bytes to meet command bounds
       old_str << "\x00" * old_pad

--- a/lib/macho/open.rb
+++ b/lib/macho/open.rb
@@ -12,9 +12,9 @@ module MachO
 
     magic = File.open(filename, "rb") { |f| f.read(4) }.unpack("N").first
 
-    if MachO.fat_magic?(magic)
+    if Utils.fat_magic?(magic)
       file = FatFile.new(filename)
-    elsif MachO.magic?(magic)
+    elsif Utils.magic?(magic)
       file = MachOFile.new(filename)
     else
       raise MagicError.new(magic)

--- a/lib/macho/structure.rb
+++ b/lib/macho/structure.rb
@@ -18,21 +18,9 @@ module MachO
     # @return [MachO::MachOStructure] a new MachOStructure initialized with `bin`
     # @api private
     def self.new_from_bin(endianness, bin)
-      format = specialize_format(self::FORMAT, endianness)
+      format = Utils.specialize_format(self::FORMAT, endianness)
 
       self.new(*bin.unpack(format))
-    end
-
-    private
-
-    # Convert an abstract (native-endian) String#unpack format to big or little.
-    # @param format [String] the format string being converted
-    # @param endianness [Symbol] either `:big` or `:little`
-    # @return [String] the converted string
-    # @api private
-    def self.specialize_format(format, endianness)
-      modifier = (endianness == :big) ? ">" : "<"
-      format.tr("=", modifier)
     end
   end
 end

--- a/lib/macho/utils.rb
+++ b/lib/macho/utils.rb
@@ -1,48 +1,59 @@
 module MachO
-  # @param value [Fixnum] the number being rounded
-  # @param round [Fixnum] the number being rounded with
-  # @return [Fixnum] the next number >= `value` such that `round` is its divisor
-  # @see http://www.opensource.apple.com/source/cctools/cctools-870/libstuff/rnd.c
-  def self.round(value, round)
-    round -= 1
-    value += round
-    value &= ~round
-    value
-  end
+  module Utils
+    # @param value [Fixnum] the number being rounded
+    # @param round [Fixnum] the number being rounded with
+    # @return [Fixnum] the next number >= `value` such that `round` is its divisor
+    # @see http://www.opensource.apple.com/source/cctools/cctools-870/libstuff/rnd.c
+    def self.round(value, round)
+      round -= 1
+      value += round
+      value &= ~round
+      value
+    end
 
-  # @param num [Fixnum] the number being checked
-  # @return [Boolean] true if `num` is a valid Mach-O magic number, false otherwise
-  def self.magic?(num)
-    MH_MAGICS.has_key?(num)
-  end
+    # Convert an abstract (native-endian) String#unpack format to big or little.
+    # @param format [String] the format string being converted
+    # @param endianness [Symbol] either `:big` or `:little`
+    # @return [String] the converted string
+    def self.specialize_format(format, endianness)
+      modifier = (endianness == :big) ? ">" : "<"
+      format.tr("=", modifier)
+    end
 
-  # @param num [Fixnum] the number being checked
-  # @return [Boolean] true if `num` is a valid Fat magic number, false otherwise
-  def self.fat_magic?(num)
-    num == FAT_MAGIC
-  end
+    # @param num [Fixnum] the number being checked
+    # @return [Boolean] true if `num` is a valid Mach-O magic number, false otherwise
+    def self.magic?(num)
+      MH_MAGICS.has_key?(num)
+    end
 
-  # @param num [Fixnum] the number being checked
-  # @return [Boolean] true if `num` is a valid 32-bit magic number, false otherwise
-  def self.magic32?(num)
-    num == MH_MAGIC || num == MH_CIGAM
-  end
+    # @param num [Fixnum] the number being checked
+    # @return [Boolean] true if `num` is a valid Fat magic number, false otherwise
+    def self.fat_magic?(num)
+      num == FAT_MAGIC
+    end
 
-  # @param num [Fixnum] the number being checked
-  # @return [Boolean] true if `num` is a valid 64-bit magic number, false otherwise
-  def self.magic64?(num)
-    num == MH_MAGIC_64 || num == MH_CIGAM_64
-  end
+    # @param num [Fixnum] the number being checked
+    # @return [Boolean] true if `num` is a valid 32-bit magic number, false otherwise
+    def self.magic32?(num)
+      num == MH_MAGIC || num == MH_CIGAM
+    end
 
-  # @param num [Fixnum] the number being checked
-  # @return [Boolean] true if `num` is a valid little-endian magic number, false otherwise
-  def self.little_magic?(num)
-    num == MH_CIGAM || num == MH_CIGAM_64
-  end
+    # @param num [Fixnum] the number being checked
+    # @return [Boolean] true if `num` is a valid 64-bit magic number, false otherwise
+    def self.magic64?(num)
+      num == MH_MAGIC_64 || num == MH_CIGAM_64
+    end
 
-  # @param num [Fixnum] the number being checked
-  # @return [Boolean] true if `num` is a valid big-endian magic number, false otherwise
-  def self.big_magic?(num)
-    num == MH_CIGAM || num == MH_CIGAM_64
+    # @param num [Fixnum] the number being checked
+    # @return [Boolean] true if `num` is a valid little-endian magic number, false otherwise
+    def self.little_magic?(num)
+      num == MH_CIGAM || num == MH_CIGAM_64
+    end
+
+    # @param num [Fixnum] the number being checked
+    # @return [Boolean] true if `num` is a valid big-endian magic number, false otherwise
+    def self.big_magic?(num)
+      num == MH_CIGAM || num == MH_CIGAM_64
+    end
   end
 end


### PR DESCRIPTION
This one is *probably* safe to merge, but I'd like some tests before I do so.
Do you have any ideas on getting `clang`/`ld` to emit a two-level namespace hints lookup table?

cc @UniqMartin 