### PR TITLE
Add LoadCommand.create for creating independent load commands.

### DIFF
--- a/lib/macho/exceptions.rb
+++ b/lib/macho/exceptions.rb
@@ -80,6 +80,32 @@ module MachO
     end
   end
 
+  # Raised when a load command can't be created manually.
+  class LoadCommandNotCreatableError < MachOError
+    # @param cmd_sym [Symbol] the uncreatable load command's symbol
+    def initialize(cmd_sym)
+      super "Load commands of type #{cmd_sym} cannot be created manually"
+    end
+  end
+
+  # Raised when the number of arguments used to create a load command manually is wrong.
+  class LoadCommandCreationArityError < MachOError
+    # @param cmd_sym [Symbol] the load command's symbol
+    # @param expected_arity [Fixnum] the number of arguments expected
+    # @param actual_arity [Fixnum] the number of arguments received
+    def initialize(cmd_sym, expected_arity, actual_arity)
+      super "Expected #{expected_arity} arguments for #{cmd_sym} creation, got #{actual_arity}"
+    end
+  end
+
+  # Raised when a load command can't be serialized.
+  class LoadCommandNotSerializableError < MachOError
+    # @param cmd_sym [Symbol] the load command's symbol
+    def initialize(cmd_sym)
+      super "Load commands of type #{cmd_sym} cannot be serialized"
+    end
+  end
+
   # Raised when load commands are too large to fit in the current file.
   class HeaderPadError < MachOError
     # @param filename [String] the filename

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -64,6 +64,10 @@ module MachO
       Utils.magic64?(header.magic)
     end
 
+    def alignment
+      magic32? ? 4 : 8
+    end
+
     # @return [Boolean] true if the file is of type `MH_OBJECT`, false otherwise
     def object?
       header.filetype == MH_OBJECT
@@ -464,12 +468,6 @@ module MachO
     # @todo This needs to be replaced.
     # @see https://github.com/Homebrew/ruby-macho/pull/35
     def set_lc_str_in_cmd(cmd, lc_str, old_str, new_str)
-      if magic32?
-        cmd_round = 4
-      else
-        cmd_round = 8
-      end
-
       new_sizeofcmds = header.sizeofcmds
       old_str = old_str.dup
       new_str = new_str.dup
@@ -478,8 +476,8 @@ module MachO
       new_prepad = cmd.class.bytesize + new_str.bytesize + 1
 
       # calculate the original and new padded sizes of the strings
-      old_padded_size = Utils.round(old_prepad, cmd_round)
-      new_padded_size = Utils.round(new_prepad, cmd_round)
+      old_padded_size = Utils.round(old_prepad, alignment)
+      new_padded_size = Utils.round(new_prepad, alignment)
 
       # calculate the number of pad bytes used in the old and new strings
       old_pad = old_padded_size - (old_prepad)

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -6,18 +6,25 @@ require "tempfile"
 module Helpers
   OTOOL_RX = /\t(.*) \(compatibility version (?:\d+\.)*\d+, current version (?:\d+\.)*\d+\)/
 
-  # architectures used in testing single-arch binaries
-  SINGLE_ARCHES = [
+  # architectures used in testing 32-bit single-arch binaries
+  SINGLE_32_ARCHES = [
     :i386,
+    :ppc,
+  ].freeze
+
+  # architectures used in testing 64-bit single-arch binaries
+  SINGLE_64_ARCHES = [
     :x86_64,
-    :ppc
-  ]
+  ].freeze
+
+  # architectures used in testing single-arch binaries
+  SINGLE_ARCHES = SINGLE_32_ARCHES + SINGLE_64_ARCHES
 
   # architecture pairs used in testing fat binaries
   FAT_ARCH_PAIRS = [
     [:i386, :x86_64],
     [:i386, :ppc]
-  ]
+  ].freeze
 
   def fixture(archs, name)
     arch_dir = archs.is_a?(Array) ? "fat-#{archs.join("-")}" : archs.to_s

--- a/test/test_create_load_commands.rb
+++ b/test/test_create_load_commands.rb
@@ -1,0 +1,46 @@
+require "minitest/autorun"
+require "helpers"
+require "macho"
+
+class MachOLoadCommandCreationTest < Minitest::Test
+  include Helpers
+
+  def test_create_uncreatable_command
+    assert_raises MachO::LoadCommandNotCreatableError do
+      MachO::LoadCommand.create(:LC_SEGMENT, 4)
+    end
+  end
+
+  def test_create_wrong_command_arity
+    assert_raises MachO::LoadCommandCreationArityError do
+      MachO::LoadCommand.create(:LC_ID_DYLIB, 4, "missing arguments")
+    end
+  end
+
+  def test_create_dylib_commands
+    # all dylib commands are creatable, so test them all
+    dylib_commands = MachO::DYLIB_LOAD_COMMANDS + [:LC_ID_DYLIB]
+    dylib_commands.each do |cmd_sym|
+      lc = MachO::LoadCommand.create(cmd_sym, "test", 0, 0, 0)
+
+      assert lc
+      assert_kind_of MachO::DylibCommand, lc
+      assert lc.name
+      assert_kind_of MachO::LoadCommand::LCStr, lc.name
+      assert_equal "test", lc.name.to_s
+      assert_equal 0, lc.timestamp
+      assert_equal 0, lc.current_version
+      assert_equal 0, lc.compatibility_version
+    end
+  end
+
+  def test_create_rpath_command
+    lc = MachO::LoadCommand.create(:LC_RPATH, "test")
+
+    assert lc
+    assert_kind_of MachO::RpathCommand, lc
+    assert lc.path
+    assert_kind_of MachO::LoadCommand::LCStr, lc.path
+    assert_equal "test", lc.path.to_s
+  end
+end

--- a/test/test_serialize_load_commands.rb
+++ b/test/test_serialize_load_commands.rb
@@ -1,0 +1,257 @@
+require "minitest/autorun"
+require "helpers"
+require "macho"
+
+class MachOLoadCommandSerializationTest < Minitest::Test
+  include Helpers
+
+  def test_can_serialize
+    filename = fixture(:i386, "hello.bin")
+    file = MachO::MachOFile.new(filename)
+    lc = file[:LC_SEGMENT].first
+
+    refute lc.serializable?
+
+    assert_raises MachO::LoadCommandNotSerializableError do
+      lc.serialize(MachO::LoadCommand::SerializationContext.context_for(file))
+    end
+  end
+
+  def test_serialize_segment
+    pass
+  end
+
+  def test_serialize_symtab
+    pass
+  end
+
+  def test_serialize_symseg
+    pass
+  end
+
+  def test_serialize_thread
+    pass
+  end
+
+  def test_serialize_unixthread
+    pass
+  end
+
+  def test_serialize_loadfvmlib
+    pass
+  end
+
+  def test_serialize_ident
+    pass
+  end
+
+  def test_serialize_fvmfile
+    pass
+  end
+
+  def test_serialize_prepage
+    pass
+  end
+
+  def test_serialize_dysymtab
+    pass
+  end
+
+  def test_serialize_load_dylib
+    filenames = SINGLE_ARCHES.map { |a| fixture(a, "hello.bin") }
+
+    filenames.each do |filename|
+      file = MachO::MachOFile.new(filename)
+      ctx = MachO::LoadCommand::SerializationContext.context_for(file)
+      lc = file[:LC_LOAD_DYLIB].first
+      lc2 = MachO::LoadCommand.create(:LC_LOAD_DYLIB, lc.name.to_s,
+        lc.timestamp, lc.current_version, lc.compatibility_version)
+      blob = lc.view.raw_data[lc.view.offset, lc.cmdsize]
+
+      assert_equal blob, lc.serialize(ctx)
+      assert_equal blob, lc2.serialize(ctx)
+    end
+  end
+
+  def test_serialize_id_dylib
+    filenames = SINGLE_ARCHES.map { |a| fixture(a, "libhello.dylib") }
+
+    filenames.each do |filename|
+      file = MachO::MachOFile.new(filename)
+      ctx = MachO::LoadCommand::SerializationContext.context_for(file)
+      lc = file[:LC_ID_DYLIB].first
+      lc2 = MachO::LoadCommand.create(:LC_ID_DYLIB, lc.name.to_s,
+        lc.timestamp, lc.current_version, lc.compatibility_version)
+      blob = lc.view.raw_data[lc.view.offset, lc.cmdsize]
+
+      assert_equal blob, lc.serialize(ctx)
+      assert_equal blob, lc2.serialize(ctx)
+    end
+  end
+
+  def test_serialize_load_dylinker
+    filenames = SINGLE_ARCHES.map { |a| fixture(a, "hello.bin") }
+
+    filenames.each do |filename|
+      file = MachO::MachOFile.new(filename)
+      ctx = MachO::LoadCommand::SerializationContext.context_for(file)
+      lc = file[:LC_LOAD_DYLINKER].first
+      lc2 = MachO::LoadCommand.create(:LC_LOAD_DYLINKER, lc.name.to_s)
+      blob = lc.view.raw_data[lc.view.offset, lc.cmdsize]
+
+      assert_equal blob, lc.serialize(ctx)
+      assert_equal blob, lc2.serialize(ctx)
+    end
+  end
+
+  def test_serialize_id_dylinker
+    pass
+  end
+
+  def test_serialize_prebound_dylib
+    pass
+  end
+
+  def test_serialize_routines
+    pass
+  end
+
+  def test_serialize_sub_framework
+    pass
+  end
+
+  def test_serialize_sub_umbrella
+    pass
+  end
+
+  def test_serialize_sub_client
+    pass
+  end
+
+  def test_serialize_sub_library
+    pass
+  end
+
+  def test_serialize_twolevel_hints
+    pass
+  end
+
+  def test_serialize_prebind_cksum
+    pass
+  end
+
+  def test_serialize_load_weak_dylib
+    pass
+  end
+
+  def test_serialize_segment_64
+    pass
+  end
+
+  def test_serialize_routines_64
+    pass
+  end
+
+  def test_serialize_uuid
+    pass
+  end
+
+  def test_serialize_rpath
+    filenames = SINGLE_ARCHES.map { |a| fixture(a, "hello.bin") }
+
+    filenames.each do |filename|
+      file = MachO::MachOFile.new(filename)
+      ctx = MachO::LoadCommand::SerializationContext.context_for(file)
+      lc = file[:LC_RPATH].first
+      lc2 = MachO::LoadCommand.create(:LC_RPATH, lc.path.to_s)
+      blob = lc.view.raw_data[lc.view.offset, lc.cmdsize]
+
+      assert_equal blob, lc.serialize(ctx)
+      assert_equal blob, lc2.serialize(ctx)
+    end
+  end
+
+  def test_serialize_code_signature
+    pass
+  end
+
+  def test_serialize_segment_split_info
+    pass
+  end
+
+  def test_serialize_reexport_dylib
+    pass
+  end
+
+  def test_serialize_lazy_load_dylib
+    pass
+  end
+
+  def test_serialize_encryption_info
+    pass
+  end
+
+  def test_serialize_dyld_info
+    pass
+  end
+
+  def test_serialize_dyld_info_only
+    pass
+  end
+
+  def test_serialize_load_upward_dylib
+    pass
+  end
+
+  def test_serialize_version_min_macosx
+    pass
+  end
+
+  def test_serialize_version_min_iphoneos
+    pass
+  end
+
+  def test_serialize_function_starts
+    pass
+  end
+
+  def test_serialize_dyld_environment
+    pass
+  end
+
+  def test_serialize_main
+    pass
+  end
+
+  def test_serialize_data_in_code
+    pass
+  end
+
+  def test_serialize_source_version
+    pass
+  end
+
+  def test_serialize_dylib_code_sign_drs
+    pass
+  end
+
+  def test_serialize_encryption_info_64
+    pass
+  end
+
+  def test_serialize_linker_option
+    pass
+  end
+
+  def test_serialize_linker_optimization_hint
+    pass
+  end
+
+  def test_serialize_version_min_tvos
+    pass
+  end
+
+  def test_serialize_version_min_watchos
+    pass
+  end
+end


### PR DESCRIPTION
- [x] Creation of load commands without a view.
- [x] Serialization of created load commands.

Downsides to this approach:
* Argument order is currently unchecked, which means that users will almost certainly run into confusing bugs if they provide arguments in the order not used by structures in `libmacho` (and `ruby-macho`).

cc @UniqMartin 