### PR TITLE
Add rpath changing to tools, tests.

### DIFF
--- a/lib/macho/tools.rb
+++ b/lib/macho/tools.rb
@@ -41,7 +41,10 @@ module MachO
     # @return [void]
     # @todo unstub
     def self.change_rpath(filename, old_path, new_path)
-      raise UnimplementedError.new("changing rpaths in a Mach-O")
+      file = MachO.open(filename)
+
+      file.change_rpath(old_path, new_path)
+      file.write!
     end
 
     # Add a runtime path to a Mach-O or Fat binary, overwriting the source file.

--- a/test/test_tools.rb
+++ b/test/test_tools.rb
@@ -30,27 +30,119 @@ class MachOToolsTest < Minitest::Test
   end
 
   def test_change_dylib_id
-    pass
+    groups = SINGLE_ARCHES.map do |arch|
+      ["libhello.dylib", "libhello_actual.dylib", "libhello_expected.dylib"].map do |fn|
+        fixture(arch, fn)
+      end
+    end
+
+    groups.each do |filename, actual, expected|
+      FileUtils.cp filename, actual
+      MachO::Tools.change_dylib_id(actual, "test")
+
+      assert equal_sha1_hashes(actual, expected)
+    end
+  ensure
+    groups.each do |_, actual, _|
+      delete_if_exists(actual)
+    end
   end
 
   def test_change_dylib_id_fat
-    pass
+    groups = FAT_ARCH_PAIRS.map do |arch|
+      ["libhello.dylib", "libhello_actual.dylib", "libhello_expected.dylib"].map do |fn|
+        fixture(arch, fn)
+      end
+    end
+
+    groups.each do |filename, actual, expected|
+      FileUtils.cp filename, actual
+      MachO::Tools.change_dylib_id(actual, "test")
+
+      assert equal_sha1_hashes(actual, expected)
+    end
+  ensure
+    groups.each do |_, actual, _|
+      delete_if_exists(actual)
+    end
   end
 
   def test_change_install_name
-    pass
+    groups = SINGLE_ARCHES.map do |arch|
+      ["hello.bin", "hello_actual.bin", "hello_expected.bin"].map do |fn|
+        fixture(arch, fn)
+      end
+    end
+
+    groups.each do |filename, actual, expected|
+      FileUtils.cp filename, actual
+      oldname = MachO::Tools.dylibs(actual).first
+      MachO::Tools.change_install_name(actual, oldname, "test")
+
+      assert equal_sha1_hashes(actual, expected)
+    end
+  ensure
+    groups.each do |_, actual, _|
+      delete_if_exists(actual)
+    end
   end
 
   def test_change_install_name_fat
-    pass
+    groups = FAT_ARCH_PAIRS.map do |arch|
+      ["hello.bin", "hello_actual.bin", "hello_expected.bin"].map do |fn|
+        fixture(arch, fn)
+      end
+    end
+
+    groups.each do |filename, actual, expected|
+      FileUtils.cp filename, actual
+      oldname = MachO::Tools.dylibs(actual).first
+      MachO::Tools.change_install_name(actual, oldname, "test")
+
+      assert equal_sha1_hashes(actual, expected)
+    end
+  ensure
+    groups.each do |_, actual, _|
+      delete_if_exists(actual)
+    end
   end
 
   def test_change_rpath
-    pass
+    groups = SINGLE_ARCHES.map do |arch|
+      ["hello.bin", "hello_actual.bin", "hello_rpath_expected.bin"].map do |fn|
+        fixture(arch, fn)
+      end
+    end
+
+    groups.each do |filename, actual, expected|
+      FileUtils.cp filename, actual
+      MachO::Tools.change_rpath(actual, "made_up_path", "/usr/lib")
+
+      assert equal_sha1_hashes(actual, expected)
+    end
+  ensure
+    groups.each do |_, actual, _|
+      delete_if_exists(actual)
+    end
   end
 
   def test_change_rpath_fat
-    pass
+    groups = FAT_ARCH_PAIRS.map do |arch|
+      ["hello.bin", "hello_actual.bin", "hello_rpath_expected.bin"].map do |fn|
+        fixture(arch, fn)
+      end
+    end
+
+    groups.each do |filename, actual, expected|
+      FileUtils.cp filename, actual
+      MachO::Tools.change_rpath(actual, "made_up_path", "/usr/lib")
+
+      assert equal_sha1_hashes(actual, expected)
+    end
+  ensure
+    groups.each do |_, actual, _|
+      delete_if_exists(actual)
+    end
   end
 
   def test_add_rpath


### PR DESCRIPTION
`Tools.add_rpath` and `Tools.delete_rpath` remain unimplemented, for the time being. I'll be implementing those in another PR.

The first shouldn't be too hard once creation/serialization of LCs is completed, and the second is just a matter of finding the right LC and removing it entirely (and updating `sizeofcmds`).
