### PR TITLE
Documentation shoring

### DIFF
--- a/lib/macho/fat_file.rb
+++ b/lib/macho/fat_file.rb
@@ -39,6 +39,8 @@ module MachO
       @machos = get_machos
     end
 
+    # Initializes a new FatFile instance from a binary string.
+    # @see MachO::FatFile.new_from_bin
     # @api private
     def initialize_from_bin(bin)
       @filename = nil
@@ -260,7 +262,7 @@ module MachO
     # @raise [MachO::MagicError] if the magic is not valid Mach-O magic
     # @raise [MachO::MachOBinaryError] if the magic is for a non-fat Mach-O file
     # @raise [MachO::JavaClassFileError] if the file is a Java classfile
-    # @private
+    # @api private
     def get_fat_header
       # the smallest fat Mach-O header is 8 bytes
       raise TruncatedFileError.new if @raw_data.size < 8
@@ -284,7 +286,7 @@ module MachO
 
     # Obtain an array of fat architectures from raw file data.
     # @return [Array<MachO::FatArch>] an array of fat architectures
-    # @private
+    # @api private
     def get_fat_archs
       archs = []
 
@@ -299,7 +301,7 @@ module MachO
 
     # Obtain an array of Mach-O blobs from raw file data.
     # @return [Array<MachO::MachOFile>] an array of Mach-Os
-    # @private
+    # @api private
     def get_machos
       machos = []
 
@@ -310,9 +312,9 @@ module MachO
       machos
     end
 
-    # @todo this needs to be redesigned. arch[:offset] and arch[:size] are
-    # already out-of-date, and the header needs to be synchronized as well.
-    # @private
+    # Synchronize the raw file data with each internal Mach-O object.
+    # @return [void]
+    # @api private
     def synchronize_raw_data
       machos.each_with_index do |macho, i|
         arch = fat_archs[i]

--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -1,25 +1,32 @@
 module MachO
   # big-endian fat magic
+  # @api private
   FAT_MAGIC = 0xcafebabe
 
   # little-endian fat magic
   # this is defined, but should never appear in ruby-macho code because
   # fat headers are always big-endian and therefore always unpacked as such.
+  # @api private
   FAT_CIGAM = 0xbebafeca
 
   # 32-bit big-endian magic
+  # @api private
   MH_MAGIC = 0xfeedface
 
   # 32-bit little-endian magic
+  # @api private
   MH_CIGAM = 0xcefaedfe
 
   # 64-bit big-endian magic
+  # @api private
   MH_MAGIC_64 = 0xfeedfacf
 
   # 64-bit little-endian magic
+  # @api private
   MH_CIGAM_64 = 0xcffaedfe
 
   # association of magic numbers to string representations
+  # @api private
   MH_MAGICS = {
     FAT_MAGIC => "FAT_MAGIC",
     MH_MAGIC => "MH_MAGIC",
@@ -29,36 +36,47 @@ module MachO
   }
 
   # mask for CPUs with 64-bit architectures (when running a 64-bit ABI?)
+  # @api private
   CPU_ARCH_ABI64 = 0x01000000
 
   # any CPU (unused?)
+  # @api private
   CPU_TYPE_ANY = -1
 
   # m68k compatible CPUs
+  # @api private
   CPU_TYPE_MC680X0 = 0x06
 
   # i386 and later compatible CPUs
+  # @api private
   CPU_TYPE_I386 = 0x07
 
   # x86_64 (AMD64) compatible CPUs
+  # @api private
   CPU_TYPE_X86_64 = (CPU_TYPE_I386 | CPU_ARCH_ABI64)
 
   # 32-bit ARM compatible CPUs
+  # @api private
   CPU_TYPE_ARM = 0x0c
 
   # m88k compatible CPUs
+  # @api private
   CPU_TYPE_MC88000 = 0xd
 
   # 64-bit ARM compatible CPUs
+  # @api private
   CPU_TYPE_ARM64 = (CPU_TYPE_ARM | CPU_ARCH_ABI64)
 
   # PowerPC compatible CPUs
+  # @api private
   CPU_TYPE_POWERPC = 0x12
 
   # PowerPC64 compatible CPUs
+  # @api private
   CPU_TYPE_POWERPC64 = (CPU_TYPE_POWERPC | CPU_ARCH_ABI64)
 
   # association of cpu types to symbol representations
+  # @api private
   CPU_TYPES = {
     CPU_TYPE_ANY => :any,
     CPU_TYPE_I386 => :i386,
@@ -70,153 +88,210 @@ module MachO
   }
 
   # mask for CPU subtype capabilities
+  # @api private
   CPU_SUBTYPE_MASK = 0xff000000
 
   # 64-bit libraries (undocumented!)
   # @see http://llvm.org/docs/doxygen/html/Support_2MachO_8h_source.html
+  # @api private
   CPU_SUBTYPE_LIB64 = 0x80000000
 
   # the lowest common sub-type for `CPU_TYPE_I386`
+  # @api private
   CPU_SUBTYPE_I386 = 3
 
   # the i486 sub-type for `CPU_TYPE_I386`
+  # @api private
   CPU_SUBTYPE_486 = 4
 
   # the i486SX sub-type for `CPU_TYPE_I386`
+  # @api private
   CPU_SUBTYPE_486SX = 132
 
   # the i586 (P5, Pentium) sub-type for `CPU_TYPE_I386`
+  # @api private
   CPU_SUBTYPE_586 = 5
+
+  # @see CPU_SUBTYPE_586
+  # @api private
   CPU_SUBTYPE_PENT  = CPU_SUBTYPE_586
 
   # the Pentium Pro (P6) sub-type for `CPU_TYPE_I386`
+  # @api private
   CPU_SUBTYPE_PENTPRO = 22
 
   # the Pentium II (P6, M3?) sub-type for `CPU_TYPE_I386`
+  # @api private
   CPU_SUBTYPE_PENTII_M3 = 54
 
   # the Pentium II (P6, M5?) sub-type for `CPU_TYPE_I386`
+  # @api private
   CPU_SUBTYPE_PENTII_M5 = 86
 
   # the Pentium 4 (Netburst) sub-type for `CPU_TYPE_I386`
+  # @api private
   CPU_SUBTYPE_PENTIUM_4 = 10
 
   # the lowest common sub-type for `CPU_TYPE_MC680X0`
+  # @api private
   CPU_SUBTYPE_MC680X0_ALL = 1
+
+  # @see CPU_SUBTYPE_MC680X0_ALL
+  # @api private
   CPU_SUBTYPE_MC68030 = CPU_SUBTYPE_MC680X0_ALL
 
   # the 040 subtype for `CPU_TYPE_MC680X0`
+  # @api private
   CPU_SUBTYPE_MC68040 = 2
 
   # the 030 subtype for `CPU_TYPE_MC680X0`
+  # @api private
   CPU_SUBTYPE_MC68030_ONLY = 3
 
   # the lowest common sub-type for `CPU_TYPE_X86_64`
+  # @api private
   CPU_SUBTYPE_X86_64_ALL = CPU_SUBTYPE_I386
 
   # the Haskell sub-type for `CPU_TYPE_X86_64`
+  # @api private
   CPU_SUBTYPE_X86_64_H = 8
 
   # the lowest common sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_ALL = 0
 
   # the v4t sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V4T = 5
 
   # the v6 sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V6 = 6
 
   # the v5 sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V5TEJ = 7
 
   # the xscale (v5 family) sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_XSCALE = 8
 
   # the v7 sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V7 = 9
 
   # the v7f (Cortex A9) sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V7F = 10
 
   # the v7s ("Swift") sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V7S = 11
 
   # the v7k ("Kirkwood40") sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V7K = 12
 
   # the v6m sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V6M = 14
 
   # the v7m sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V7M = 15
 
   # the v7em sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V7EM = 16
 
   # the v8 sub-type for `CPU_TYPE_ARM`
+  # @api private
   CPU_SUBTYPE_ARM_V8 = 13
 
   # the lowest common sub-type for `CPU_TYPE_ARM64`
+  # @api private
   CPU_SUBTYPE_ARM64_ALL = 0
 
   # the v8 sub-type for `CPU_TYPE_ARM64`
+  # @api private
   CPU_SUBTYPE_ARM64_V8 = 1
 
   # the lowest common sub-type for `CPU_TYPE_MC88000`
+  # @api private
   CPU_SUBTYPE_MC88000_ALL = 0
+
+  # @see CPU_SUBTYPE_MC88000_ALL
+  # @api private
   CPU_SUBTYPE_MMAX_JPC = CPU_SUBTYPE_MC88000_ALL
 
   # the 100 sub-type for `CPU_TYPE_MC88000`
+  # @api private
   CPU_SUBTYPE_MC88100 = 1
 
   # the 110 sub-type for `CPU_TYPE_MC88000`
+  # @api private
   CPU_SUBTYPE_MC88110 = 2
 
   # the lowest common sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_ALL = 0
 
   # the 601 sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_601 = 1
 
   # the 602 sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_602 = 2
 
   # the 603 sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_603 = 3
 
   # the 603e (G2) sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_603E = 4
 
   # the 603ev sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_603EV = 5
 
   # the 604 sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_604 = 6
 
   # the 604e sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_604E = 7
 
   # the 620 sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_620 = 8
 
   # the 750 (G3) sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_750 = 9
 
   # the 7400 (G4) sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_7400 = 10
 
   # the 7450 (G4 "Voyager") sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_7450 = 11
 
   # the 970 (G5) sub-type for `CPU_TYPE_POWERPC`
+  # @api private
   CPU_SUBTYPE_POWERPC_970 = 100
 
   # any CPU sub-type for CPU type `CPU_TYPE_POWERPC64`
+  # @api private
   CPU_SUBTYPE_POWERPC64_ALL = CPU_SUBTYPE_POWERPC_ALL
 
   # association of CPU types/subtype pairs to symbol representations in
   # (very) roughly descending order of commonness
   # @see https://opensource.apple.com/source/cctools/cctools-877.8/libstuff/arch.c
+  # @api private
   CPU_SUBTYPES = {
     CPU_TYPE_I386 => {
       CPU_SUBTYPE_I386 => :i386,
@@ -280,36 +355,47 @@ module MachO
   }.freeze
 
   # relocatable object file
+  # @api private
   MH_OBJECT = 0x1
 
   # demand paged executable file
+  # @api private
   MH_EXECUTE = 0x2
 
   # fixed VM shared library file
+  # @api private
   MH_FVMLIB = 0x3
 
   # core dump file
+  # @api private
   MH_CORE = 0x4
 
   # preloaded executable file
+  # @api private
   MH_PRELOAD = 0x5
 
   # dynamically bound shared library
+  # @api private
   MH_DYLIB = 0x6
 
   # dynamic link editor
+  # @api private
   MH_DYLINKER = 0x7
 
   # dynamically bound bundle file
+  # @api private
   MH_BUNDLE = 0x8
 
   # shared library stub for static linking only, no section contents
+  # @api private
   MH_DYLIB_STUB = 0x9
 
   # companion file with only debug sections
+  # @api private
   MH_DSYM = 0xa
 
   # x86_64 kexts
+  # @api private
   MH_KEXT_BUNDLE = 0xb
 
   # association of filetypes to Symbol representations
@@ -369,7 +455,12 @@ module MachO
     attr_reader :nfat_arch
 
     # always big-endian
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "N2"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 8
 
     # @api private
@@ -399,7 +490,12 @@ module MachO
     attr_reader :align
 
     # always big-endian
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "N5"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 20
 
     # @api private
@@ -435,7 +531,12 @@ module MachO
     # @return [Fixnum] the header flags associated with the Mach-O
     attr_reader :flags
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=7"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 28
 
     # @api private
@@ -468,7 +569,12 @@ module MachO
     # @return [void]
     attr_reader :reserved
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=8"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 32
 
     # @api private

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -1,6 +1,7 @@
 module MachO
   # load commands added after OS X 10.1 need to be bitwise ORed with
   # LC_REQ_DYLD to be recognized by the dynamic linder (dyld)
+  # @api private
   LC_REQ_DYLD = 0x80000000
 
   # association of load commands to symbol representations
@@ -57,6 +58,8 @@ module MachO
     0x30 => :LC_VERSION_MIN_WATCHOS,
   }.freeze
 
+  # association of symbol representations to load command constants
+  # @api private
   LOAD_COMMAND_CONSTANTS = LOAD_COMMANDS.invert.freeze
 
   # load commands responsible for loading dylibs
@@ -167,7 +170,12 @@ module MachO
     # @return [Fixnum] the size of the load command, in bytes
     attr_reader :cmdsize
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 8
 
     # Instantiates a new LoadCommand given a view into its origin Mach-O
@@ -310,7 +318,12 @@ module MachO
     # @return [Array<Fixnum>] the UUID
     attr_reader :uuid
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2a16"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 24
 
     # @api private
@@ -361,7 +374,12 @@ module MachO
     # @return [Fixnum] any flags associated with the segment
     attr_reader :flags
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2a16L=4l=2L=2"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 56
 
     # @api private
@@ -420,7 +438,12 @@ module MachO
     # @return [Fixnum] any flags associated with the segment
     attr_reader :flags
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2a16Q=4l=2L=2"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 72
 
     # @api private
@@ -465,7 +488,12 @@ module MachO
     # @return [Fixnum] the library's compatibility version number
     attr_reader :compatibility_version
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=6"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 24
 
     # @api private
@@ -496,7 +524,12 @@ module MachO
     # @return [MachO::LoadCommand::LCStr] the dynamic linker's path name as an LCStr
     attr_reader :name
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=3"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 12
 
     # @api private
@@ -528,7 +561,12 @@ module MachO
     # @return [Fixnum] a bit vector of linked modules
     attr_reader :linked_modules
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=5"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 20
 
     # @api private
@@ -543,7 +581,12 @@ module MachO
   # A load command used to represent threads.
   # @note cctools-870 has all fields of thread_command commented out except common ones (cmd, cmdsize)
   class ThreadCommand < LoadCommand
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 8
   end
 
@@ -575,7 +618,12 @@ module MachO
     # @return [void]
     attr_reader :reserved6
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=10"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 40
 
     # @api private
@@ -621,7 +669,12 @@ module MachO
     # @return [void]
     attr_reader :reserved6
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2Q=8"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 72
 
     # @api private
@@ -645,7 +698,12 @@ module MachO
     # @return [MachO::LoadCommand::LCStr] the umbrella framework name as an LCStr
     attr_reader :umbrella
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=3"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 12
 
     # @api private
@@ -661,7 +719,12 @@ module MachO
     # @return [MachO::LoadCommand::LCStr] the subumbrella framework name as an LCStr
     attr_reader :sub_umbrella
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=3"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 12
 
     # @api private
@@ -677,7 +740,12 @@ module MachO
     # @return [MachO::LoadCommand::LCStr] the sublibrary name as an LCStr
     attr_reader :sub_library
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=3"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 12
 
     # @api private
@@ -693,7 +761,12 @@ module MachO
     # @return [MachO::LoadCommand::LCStr] the subclient name as an LCStr
     attr_reader :sub_client
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=3"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 12
 
     # @api private
@@ -718,7 +791,12 @@ module MachO
     # @return the string table size in bytes
     attr_reader :strsize
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=6"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 24
 
     # @api private
@@ -789,7 +867,12 @@ module MachO
     attr_reader :nlocrel
 
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=20"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 80
 
     # ugh
@@ -832,7 +915,12 @@ module MachO
     # @return [MachO::TwolevelHintsCommand::TwolevelHintTable] the hint table
     attr_reader :table
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=4"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 16
 
     # @api private
@@ -885,7 +973,12 @@ module MachO
     # @return [Fixnum] the checksum or 0
     attr_reader :cksum
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=3"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 12
 
     # @api private
@@ -902,7 +995,12 @@ module MachO
     # @return [MachO::LoadCommand::LCStr] the path to add to the run path as an LCStr
     attr_reader :path
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=3"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 12
 
     # @api private
@@ -932,7 +1030,12 @@ module MachO
     # @return [Fixnum] size of the data in the __LINKEDIT segment
     attr_reader :datasize
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=4"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 16
 
     # @api private
@@ -955,7 +1058,12 @@ module MachO
     # @return [Fixnum] the encryption system, or 0 if not encrypted yet
     attr_reader :cryptid
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=5"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 20
 
     # @api private
@@ -982,7 +1090,12 @@ module MachO
     # @return [Fixnum] 64-bit padding value
     attr_reader :pad
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=6"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 24
 
     # @api private
@@ -1004,7 +1117,12 @@ module MachO
     # @return [Fixnum] the SDK version X.Y.Z packed as x16.y8.z8
     attr_reader :sdk
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=4"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 16
 
     # @api private
@@ -1071,7 +1189,12 @@ module MachO
     # @return [Fixnum] the size of the export information
     attr_reader :export_size
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=12"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 48
 
     # @api private
@@ -1098,7 +1221,12 @@ module MachO
     # @return [Fixnum] the number of strings
     attr_reader :count
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=3"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 12
 
     # @api private
@@ -1116,7 +1244,12 @@ module MachO
     # @return [Fixnum] if not 0, the initial stack size.
     attr_reader :stacksize
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2Q=2"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 24
 
     # @api private
@@ -1133,7 +1266,12 @@ module MachO
     # @return [Fixnum] the version packed as a24.b10.c10.d10.e10
     attr_reader :version
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2Q=1"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 16
 
     # @api private
@@ -1164,7 +1302,12 @@ module MachO
     # @return [Fixnum] the size of the symbol segment in bytes
     attr_reader :size
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=4"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 16
 
     # @api private
@@ -1179,7 +1322,12 @@ module MachO
   # is null-terminated and the command is zero-padded to a multiple of 4.
   # Corresponds to LC_IDENT.
   class IdentCommand < LoadCommand
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=2"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 8
   end
 
@@ -1192,7 +1340,12 @@ module MachO
     # @return [Fixnum] the virtual address being loaded at
     attr_reader :header_addr
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=4"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 16
 
     def initialize(view, cmd, cmdsize, name, header_addr)
@@ -1214,7 +1367,12 @@ module MachO
     # @return [Fixnum] the library's header address
     attr_reader :header_addr
 
+    # @see MachOStructure::FORMAT
+    # @api private
     FORMAT = "L=5"
+
+    # @see MachOStructure::SIZEOF
+    # @api private
     SIZEOF = 20
 
     def initialize(view, cmd, cmdsize, name, minor_version, header_addr)

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -40,6 +40,8 @@ module MachO
       @load_commands = get_load_commands
     end
 
+    # Initializes a new MachOFile instance from a binary string.
+    # @see MachO::MachOFile.new_from_bin
     # @api private
     def initialize_from_bin(bin)
       @filename = nil
@@ -64,6 +66,7 @@ module MachO
       Utils.magic64?(header.magic)
     end
 
+    # @return [Fixnum] the file's internal alignment
     def alignment
       magic32? ? 4 : 8
     end
@@ -394,7 +397,7 @@ module MachO
     # @return [MachO::MachHeader] if the Mach-O is 32-bit
     # @return [MachO::MachHeader64] if the Mach-O is 64-bit
     # @raise [MachO::TruncatedFileError] if the file is too small to have a valid header
-    # @private
+    # @api private
     def get_mach_header
       # the smallest Mach-O header is 28 bytes
       raise TruncatedFileError.new if @raw_data.size < 28
@@ -414,7 +417,7 @@ module MachO
     # @return [Fixnum] the magic
     # @raise [MachO::MagicError] if the magic is not valid Mach-O magic
     # @raise [MachO::FatBinaryError] if the magic is for a Fat file
-    # @private
+    # @api private
     def get_and_check_magic
       magic = @raw_data[0..3].unpack("N").first
 
@@ -429,7 +432,7 @@ module MachO
     # Check the file's CPU type.
     # @param cputype [Fixnum] the CPU type
     # @raise [MachO::CPUTypeError] if the CPU type is unknown
-    # @private
+    # @api private
     def check_cputype(cputype)
       raise CPUTypeError.new(cputype) unless CPU_TYPES.key?(cputype)
     end
@@ -437,7 +440,7 @@ module MachO
     # Check the file's CPU type/subtype pair.
     # @param cpusubtype [Fixnum] the CPU subtype
     # @raise [MachO::CPUSubtypeError] if the CPU sub-type is unknown
-    # @private
+    # @api private
     def check_cpusubtype(cputype, cpusubtype)
       # Only check sub-type w/o capability bits (see `get_mach_header`).
       raise CPUSubtypeError.new(cputype, cpusubtype) unless CPU_SUBTYPES[cputype].key?(cpusubtype)
@@ -446,7 +449,7 @@ module MachO
     # Check the file's type.
     # @param filetype [Fixnum] the file type
     # @raise [MachO::FiletypeError] if the file type is unknown
-    # @private
+    # @api private
     def check_filetype(filetype)
       raise FiletypeError.new(filetype) unless MH_FILETYPES.key?(filetype)
     end
@@ -454,7 +457,7 @@ module MachO
     # All load commands in the file.
     # @return [Array<MachO::LoadCommand>] an array of load commands
     # @raise [MachO::LoadCommandError] if an unknown load command is encountered
-    # @private
+    # @api private
     def get_load_commands
       offset = header.class.bytesize
       load_commands = []
@@ -481,7 +484,7 @@ module MachO
 
     # The low file offset (offset to first section data).
     # @return [Fixnum] the offset
-    # @private
+    # @api private
     def low_fileoff
       offset = @raw_data.size
 
@@ -502,7 +505,7 @@ module MachO
     # Updates the number of load commands in the raw data.
     # @param ncmds [Fixnum] the new number of commands
     # @return [void]
-    # @private
+    # @api private
     def set_ncmds(ncmds)
       fmt = Utils.specialize_format("L=", endianness)
       ncmds_raw = [ncmds].pack(fmt)
@@ -512,7 +515,7 @@ module MachO
     # Updates the size of all load commands in the raw data.
     # @param size [Fixnum] the new size, in bytes
     # @return [void]
-    # @private
+    # @api private
     def set_sizeofcmds(size)
       fmt = Utils.specialize_format("L=", endianness)
       size_raw = [size].pack(fmt)

--- a/lib/macho/sections.rb
+++ b/lib/macho/sections.rb
@@ -100,7 +100,10 @@ module MachO
     # @return [void] reserved (for count or sizeof)
     attr_reader :reserved2
 
+    # @see MachOStructure::FORMAT
     FORMAT = "a16a16L=9"
+
+    # @see MachOStructure::SIZEOF
     SIZEOF = 68
 
     # @api private
@@ -145,7 +148,10 @@ module MachO
     # @return [void] reserved
     attr_reader :reserved3
 
+    # @see MachOStructure::FORMAT
     FORMAT = "a16a16Q=2L=8"
+
+    # @see MachOStructure::SIZEOF
     SIZEOF = 80
 
     # @api private

--- a/lib/macho/structure.rb
+++ b/lib/macho/structure.rb
@@ -3,9 +3,13 @@ module MachO
   # @abstract
   class MachOStructure
     # The String#unpack format of the data structure.
+    # @return [String] the unpacking format
+    # @api private
     FORMAT = ""
 
     # The size of the data structure, in bytes.
+    # @return [Fixnum] the size, in bytes
+    # @api private
     SIZEOF = 0
 
     # @return [Fixnum] the size, in bytes, of the represented structure.

--- a/lib/macho/utils.rb
+++ b/lib/macho/utils.rb
@@ -1,8 +1,10 @@
 module MachO
+  # A collection of utility functions used throughout ruby-macho.
   module Utils
+    # Rounds a value to the next multiple of the given round.
     # @param value [Fixnum] the number being rounded
     # @param round [Fixnum] the number being rounded with
-    # @return [Fixnum] the next number >= `value` such that `round` is its divisor
+    # @return [Fixnum] the rounded value
     # @see http://www.opensource.apple.com/source/cctools/cctools-870/libstuff/rnd.c
     def self.round(value, round)
       round -= 1
@@ -11,6 +13,7 @@ module MachO
       value
     end
 
+    # Returns the number of bytes needed to pad the given size to the given alignment.
     # @param size [Fixnum] the unpadded size
     # @param alignment [Fixnum] the number to alignment the size with
     # @return [Fixnum] the number of pad bytes required
@@ -18,7 +21,7 @@ module MachO
       round(size, alignment) - size
     end
 
-    # Convert an abstract (native-endian) String#unpack format to big or little.
+    # Converts an abstract (native-endian) String#unpack format to big or little.
     # @param format [String] the format string being converted
     # @param endianness [Symbol] either `:big` or `:little`
     # @return [String] the converted string
@@ -27,10 +30,11 @@ module MachO
       format.tr("=", modifier)
     end
 
+    # Packs tagged strings into an aligned payload.
     # @param fixed_offset [Fixnum] the baseline offset for the first packed string
     # @param alignment [Fixnum] the alignment value to use for packing
     # @param strings [Hash] the labeled strings to pack
-    # @return Array<String, Hash> the packed string and labeled offsets
+    # @return [Array<String, Hash>] the packed string and labeled offsets
     def self.pack_strings(fixed_offset, alignment, strings = {})
       offsets = {}
       next_offset = fixed_offset
@@ -47,36 +51,42 @@ module MachO
       [payload, offsets]
     end
 
+    # Compares the given number to valid Mach-O magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid Mach-O magic number, false otherwise
     def self.magic?(num)
       MH_MAGICS.has_key?(num)
     end
 
+    # Compares the given number to valid Fat magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid Fat magic number, false otherwise
     def self.fat_magic?(num)
       num == FAT_MAGIC
     end
 
+    # Compares the given number to valid 32-bit Mach-O magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid 32-bit magic number, false otherwise
     def self.magic32?(num)
       num == MH_MAGIC || num == MH_CIGAM
     end
 
+    # Compares the given number to valid 64-bit Mach-O magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid 64-bit magic number, false otherwise
     def self.magic64?(num)
       num == MH_MAGIC_64 || num == MH_CIGAM_64
     end
 
+    # Compares the given number to valid little-endian magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid little-endian magic number, false otherwise
     def self.little_magic?(num)
       num == MH_CIGAM || num == MH_CIGAM_64
     end
 
+    # Compares the given number to valid big-endian magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid big-endian magic number, false otherwise
     def self.big_magic?(num)


### PR DESCRIPTION
* Properly mark constants as private.

* Fill in some missing method descriptions and correct
formatting errors.

* Prefer "@api private" to "@private" from here on out.

This is low priority, since it doesn't actually change anything in code. On the other hand, it finally gets us to 100% yardoc coverage :tada: 

cc @UniqMartin 