### PR TITLE
macho_file: Preserve a dylib's type when changing it.

### DIFF
--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -342,7 +342,7 @@ module MachO
       old_lc = dylib_load_commands.find { |d| d.name.to_s == old_name }
       raise DylibUnknownError.new(old_name) if old_lc.nil?
 
-      new_lc = LoadCommand.create(:LC_LOAD_DYLIB, new_name,
+      new_lc = LoadCommand.create(old_lc.type, new_name,
         old_lc.timestamp, old_lc.current_version, old_lc.compatibility_version)
 
       replace_command(old_lc, new_lc)

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -339,6 +339,18 @@ class MachOFileTest < Minitest::Test
     end
   end
 
+  def test_change_install_name_preserves_type
+    filename = fixture(:i386, "libextrahello.dylib")
+
+    file = MachO::MachOFile.new(filename)
+    old_dylib_types = file.dylib_load_commands.map(&:type)
+    # this particular dylib is an LC_LOAD_UPWARD_DYLIB
+    file.change_install_name("/usr/lib/libz.1.dylib", "test")
+    new_dylib_types = file.dylib_load_commands.map(&:type)
+
+    assert_equal old_dylib_types, new_dylib_types
+  end
+
   def test_get_rpaths
     filenames = SINGLE_ARCHES.map { |a| fixture(a, "hello.bin") }
 


### PR DESCRIPTION
Fixes a bug where all changed install names were turned into
LC_LOAD_DYLIB commands.

ref #51 
cc @UniqMartin 