### PR TITLE
Allow suppression of exceptions with strict: false

### DIFF
--- a/lib/macho/tools.rb
+++ b/lib/macho/tools.rb
@@ -12,11 +12,14 @@ module MachO
     # Changes the dylib ID of a Mach-O or Fat binary, overwriting the source file.
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param new_id [String] the new dylib ID for the binary
+    # @param options [Hash]
+    # @option options [Boolean] :strict (true) whether or not to fail loudly
+    #  with an exception if the change cannot be performed
     # @return [void]
-    def self.change_dylib_id(filename, new_id)
+    def self.change_dylib_id(filename, new_id, options = {})
       file = MachO.open(filename)
 
-      file.dylib_id = new_id
+      file.change_dylib_id(new_id, options)
       file.write!
     end
 
@@ -24,11 +27,14 @@ module MachO
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param old_name [String] the old shared library name
     # @param new_name [String] the new shared library name
+    # @param options [Hash]
+    # @option options [Boolean] :strict (true) whether or not to fail loudly
+    #  with an exception if the change cannot be performed
     # @return [void]
-    def self.change_install_name(filename, old_name, new_name)
+    def self.change_install_name(filename, old_name, new_name, options = {})
       file = MachO.open(filename)
 
-      file.change_install_name(old_name, new_name)
+      file.change_install_name(old_name, new_name, options)
       file.write!
     end
 
@@ -36,34 +42,42 @@ module MachO
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param old_path [String] the old runtime path
     # @param new_path [String] the new runtime path
+    # @param options [Hash]
+    # @option options [Boolean] :strict (true) whether or not to fail loudly
+    #  with an exception if the change cannot be performed
     # @return [void]
-    def self.change_rpath(filename, old_path, new_path)
+    def self.change_rpath(filename, old_path, new_path, options = {})
       file = MachO.open(filename)
 
-      file.change_rpath(old_path, new_path)
+      file.change_rpath(old_path, new_path, options)
       file.write!
     end
 
     # Add a runtime path to a Mach-O or Fat binary, overwriting the source file.
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param new_path [String] the new runtime path
+    # @param options [Hash]
+    # @option options [Boolean] :strict (true) whether or not to fail loudly
+    #  with an exception if the change cannot be performed
     # @return [void]
-    # @todo unstub
-    def self.add_rpath(filename, new_path)
+    def self.add_rpath(filename, new_path, options = {})
       file = MachO.open(filename)
 
-      file.add_rpath(new_path)
+      file.add_rpath(new_path, options)
       file.write!
     end
 
     # Delete a runtime path from a Mach-O or Fat binary, overwriting the source file.
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param old_path [String] the old runtime path
+    # @param options [Hash]
+    # @option options [Boolean] :strict (true) whether or not to fail loudly
+    #  with an exception if the change cannot be performed
     # @return [void]
-    def self.delete_rpath(filename, old_path)
+    def self.delete_rpath(filename, old_path, options = {})
       file = MachO.open(filename)
 
-      file.delete_rpath(old_path)
+      file.delete_rpath(old_path, options)
       file.write!
     end
   end


### PR DESCRIPTION
Resolves the problem of valid discrepancies between individual Mach-Os in a fat
file causing exceptions during modifications.

ref #50 
cc @UniqMartin 