### PR TITLE
General refactoring.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,53 @@
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/FormatString:
+  EnforcedStyle: percent
+
+# we prefer compact if-else-end/case-when-end alignment
+Lint/EndAlignment:
+  AlignWith: variable
+
+Style/CaseIndentation:
+  IndentWhenRelativeTo: end
+
+# Ruby 1.8 compatibility
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
+
+# TODO: re-enable in the future
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/lib/macho/exceptions.rb
+++ b/lib/macho/exceptions.rb
@@ -146,9 +146,9 @@ module MachO
   class HeaderPadError < ModificationError
     # @param filename [String] the filename
     def initialize(filename)
-      super "Updated load commands do not fit in the header of " +
-      "#{filename}. #{filename} needs to be relinked, possibly with " +
-      "-headerpad or -headerpad_max_install_names"
+      super "Updated load commands do not fit in the header of " \
+        "#{filename}. #{filename} needs to be relinked, possibly with " \
+        "-headerpad or -headerpad_max_install_names"
     end
   end
 

--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -32,8 +32,8 @@ module MachO
     MH_MAGIC => "MH_MAGIC",
     MH_CIGAM => "MH_CIGAM",
     MH_MAGIC_64 => "MH_MAGIC_64",
-    MH_CIGAM_64 => "MH_CIGAM_64"
-  }
+    MH_CIGAM_64 => "MH_CIGAM_64",
+  }.freeze
 
   # mask for CPUs with 64-bit architectures (when running a 64-bit ABI?)
   # @api private
@@ -85,7 +85,7 @@ module MachO
     CPU_TYPE_ARM64 => :arm64,
     CPU_TYPE_POWERPC => :ppc,
     CPU_TYPE_POWERPC64 => :ppc64,
-  }
+  }.freeze
 
   # mask for CPU subtype capabilities
   # @api private
@@ -114,7 +114,7 @@ module MachO
 
   # @see CPU_SUBTYPE_586
   # @api private
-  CPU_SUBTYPE_PENT  = CPU_SUBTYPE_586
+  CPU_SUBTYPE_PENT = CPU_SUBTYPE_586
 
   # the Pentium Pro (P6) sub-type for `CPU_TYPE_I386`
   # @api private
@@ -412,7 +412,7 @@ module MachO
     MH_DYLIB_STUB => :dylib_stub,
     MH_DSYM => :dsym,
     MH_KEXT_BUNDLE => :kext_bundle,
-  }
+  }.freeze
 
   # association of mach header flag symbols to values
   # @api private
@@ -442,8 +442,8 @@ module MachO
     :MH_DEAD_STRIPPABLE_DYLIB => 0x400000,
     :MH_HAS_TLV_DESCRIPTORS => 0x800000,
     :MH_NO_HEAP_EXECUTION => 0x1000000,
-    :MH_APP_EXTENSION_SAFE => 0x02000000
-  }
+    :MH_APP_EXTENSION_SAFE => 0x02000000,
+  }.freeze
 
   # Fat binary header structure
   # @see MachO::FatArch
@@ -457,7 +457,7 @@ module MachO
     # always big-endian
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "N2"
+    FORMAT = "N2".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -492,7 +492,7 @@ module MachO
     # always big-endian
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "N5"
+    FORMAT = "N5".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -533,7 +533,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=7"
+    FORMAT = "L=7".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -541,7 +541,7 @@ module MachO
 
     # @api private
     def initialize(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds,
-        flags)
+                   flags)
       @magic = magic
       @cputype = cputype
       # For now we're not interested in additional capability bits also to be
@@ -571,7 +571,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=8"
+    FORMAT = "L=8".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -579,7 +579,7 @@ module MachO
 
     # @api private
     def initialize(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds,
-        flags, reserved)
+                   flags, reserved)
       super(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags)
       @reserved = reserved
     end

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -172,7 +172,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2"
+    FORMAT = "L=2".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -186,16 +186,16 @@ module MachO
       bin = view.raw_data.slice(view.offset, bytesize)
       format = Utils.specialize_format(self::FORMAT, view.endianness)
 
-      self.new(view, *bin.unpack(format))
+      new(view, *bin.unpack(format))
     end
 
     # Creates a new (viewless) command corresponding to the symbol provided
     # @param cmd_sym [Symbol] the symbol of the load command being created
     # @param args [Array] the arguments for the load command being created
     def self.create(cmd_sym, *args)
-      raise LoadCommandNotCreatableError.new(cmd_sym) unless CREATABLE_LOAD_COMMANDS.include?(cmd_sym)
+      raise LoadCommandNotCreatableError, cmd_sym unless CREATABLE_LOAD_COMMANDS.include?(cmd_sym)
 
-      klass = MachO.const_get "#{LC_STRUCTURES[cmd_sym]}"
+      klass = MachO.const_get LC_STRUCTURES[cmd_sym]
       cmd = LOAD_COMMAND_CONSTANTS[cmd_sym]
 
       # cmd will be filled in, view and cmdsize will be left unpopulated
@@ -227,7 +227,7 @@ module MachO
     #  if the load command can't be serialized
     # @api private
     def serialize(context)
-      raise LoadCommandNotSerializableError.new(LOAD_COMMANDS[cmd]) unless serializable?
+      raise LoadCommandNotSerializableError, LOAD_COMMANDS[cmd] unless serializable?
       format = Utils.specialize_format(FORMAT, context.endianness)
       [cmd, SIZEOF].pack(format)
     end
@@ -243,7 +243,7 @@ module MachO
       LOAD_COMMANDS[cmd]
     end
 
-    alias :to_sym :type
+    alias to_sym type
 
     # @return [String] a string representation of the load command's identifying number
     def to_s
@@ -270,8 +270,8 @@ module MachO
           lc_str_abs = view.offset + lc_str
           lc_end = view.offset + lc.cmdsize - 1
           raw_string = view.raw_data.slice(lc_str_abs..lc_end)
-          @string, null_byte, _ = raw_string.partition("\x00")
-          raise LCStrMalformedError.new(lc) if null_byte.empty?
+          @string, null_byte, _padding = raw_string.partition("\x00")
+          raise LCStrMalformedError, lc if null_byte.empty?
           @string_offset = lc_str
         else
           @string = lc_str
@@ -302,7 +302,7 @@ module MachO
       # @param macho [MachO::MachOFile] the file to contextualize
       # @return [MachO::LoadCommand::SerializationContext] the resulting context
       def self.context_for(macho)
-        self.new(macho.endianness, macho.alignment)
+        new(macho.endianness, macho.alignment)
       end
 
       # @param endianness [Symbol] the endianness of the context
@@ -323,7 +323,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2a16"
+    FORMAT = "L=2a16".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -379,7 +379,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2a16L=4l=2L=2"
+    FORMAT = "L=2a16L=4l=2L=2".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -387,7 +387,7 @@ module MachO
 
     # @api private
     def initialize(view, cmd, cmdsize, segname, vmaddr, vmsize, fileoff,
-        filesize, maxprot, initprot, nsects, flags)
+                   filesize, maxprot, initprot, nsects, flags)
       super(view, cmd, cmdsize)
       @segname = segname.delete("\x00")
       @vmaddr = vmaddr
@@ -399,7 +399,6 @@ module MachO
       @nsects = nsects
       @flags = flags
     end
-
 
     # All sections referenced within this segment.
     # @return [Array<MachO::Section>] if the Mach-O is 32-bit
@@ -434,7 +433,7 @@ module MachO
   class SegmentCommand64 < SegmentCommand
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2a16Q=4l=2L=2"
+    FORMAT = "L=2a16Q=4l=2L=2".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -459,7 +458,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=6"
+    FORMAT = "L=6".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -482,7 +481,7 @@ module MachO
       string_payload, string_offsets = Utils.pack_strings(SIZEOF, context.alignment, :name => name.to_s)
       cmdsize = SIZEOF + string_payload.bytesize
       [cmd, cmdsize, string_offsets[:name], timestamp, current_version,
-        compatibility_version].pack(format) + string_payload
+       compatibility_version].pack(format) + string_payload
     end
   end
 
@@ -495,7 +494,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=3"
+    FORMAT = "L=3".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -532,7 +531,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=5"
+    FORMAT = "L=5".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -552,7 +551,7 @@ module MachO
   class ThreadCommand < LoadCommand
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2"
+    FORMAT = "L=2".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -589,7 +588,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=10"
+    FORMAT = "L=10".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -597,7 +596,7 @@ module MachO
 
     # @api private
     def initialize(view, cmd, cmdsize, init_address, init_module, reserved1,
-        reserved2, reserved3, reserved4, reserved5, reserved6)
+                   reserved2, reserved3, reserved4, reserved5, reserved6)
       super(view, cmd, cmdsize)
       @init_address = init_address
       @init_module = init_module
@@ -640,7 +639,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2Q=8"
+    FORMAT = "L=2Q=8".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -648,7 +647,7 @@ module MachO
 
     # @api private
     def initialize(view, cmd, cmdsize, init_address, init_module, reserved1,
-        reserved2, reserved3, reserved4, reserved5, reserved6)
+                   reserved2, reserved3, reserved4, reserved5, reserved6)
       super(view, cmd, cmdsize)
       @init_address = init_address
       @init_module = init_module
@@ -669,7 +668,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=3"
+    FORMAT = "L=3".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -690,7 +689,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=3"
+    FORMAT = "L=3".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -711,7 +710,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=3"
+    FORMAT = "L=3".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -732,7 +731,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=3"
+    FORMAT = "L=3".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -762,7 +761,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=6"
+    FORMAT = "L=6".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -835,10 +834,9 @@ module MachO
     # @return [Fixnum] the number of local relocation entries
     attr_reader :nlocrel
 
-
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=20"
+    FORMAT = "L=20".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -847,9 +845,9 @@ module MachO
     # ugh
     # @api private
     def initialize(view, cmd, cmdsize, ilocalsym, nlocalsym, iextdefsym,
-        nextdefsym, iundefsym, nundefsym, tocoff, ntoc, modtaboff, nmodtab,
-        extrefsymoff, nextrefsyms, indirectsymoff, nindirectsyms, extreloff,
-        nextrel, locreloff, nlocrel)
+                   nextdefsym, iundefsym, nundefsym, tocoff, ntoc, modtaboff,
+                   nmodtab, extrefsymoff, nextrefsyms, indirectsymoff,
+                   nindirectsyms, extreloff, nextrel, locreloff, nlocrel)
       super(view, cmd, cmdsize)
       @ilocalsym = ilocalsym
       @nlocalsym = nlocalsym
@@ -886,7 +884,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=4"
+    FORMAT = "L=4".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -944,7 +942,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=3"
+    FORMAT = "L=3".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -966,7 +964,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=3"
+    FORMAT = "L=3".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1001,7 +999,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=4"
+    FORMAT = "L=4".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1029,7 +1027,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=5"
+    FORMAT = "L=5".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1061,7 +1059,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=6"
+    FORMAT = "L=6".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1088,7 +1086,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=4"
+    FORMAT = "L=4".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1160,7 +1158,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=12"
+    FORMAT = "L=12".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1168,8 +1166,8 @@ module MachO
 
     # @api private
     def initialize(view, cmd, cmdsize, rebase_off, rebase_size, bind_off,
-        bind_size, weak_bind_off, weak_bind_size, lazy_bind_off, lazy_bind_size,
-        export_off, export_size)
+                   bind_size, weak_bind_off, weak_bind_size, lazy_bind_off,
+                   lazy_bind_size, export_off, export_size)
       super(view, cmd, cmdsize)
       @rebase_off = rebase_off
       @rebase_size = rebase_size
@@ -1192,7 +1190,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=3"
+    FORMAT = "L=3".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1215,7 +1213,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2Q=2"
+    FORMAT = "L=2Q=2".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1237,7 +1235,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2Q=1"
+    FORMAT = "L=2Q=1".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1273,7 +1271,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=4"
+    FORMAT = "L=4".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1293,7 +1291,7 @@ module MachO
   class IdentCommand < LoadCommand
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=2"
+    FORMAT = "L=2".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1311,7 +1309,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=4"
+    FORMAT = "L=4".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private
@@ -1338,7 +1336,7 @@ module MachO
 
     # @see MachOStructure::FORMAT
     # @api private
-    FORMAT = "L=5"
+    FORMAT = "L=5".freeze
 
     # @see MachOStructure::SIZEOF
     # @api private

--- a/lib/macho/open.rb
+++ b/lib/macho/open.rb
@@ -7,8 +7,8 @@ module MachO
   # @raise [MachO::TruncatedFileError] if the file is too small to have a valid header
   # @raise [MachO::MagicError] if the file's magic is not valid Mach-O magic
   def self.open(filename)
-    raise ArgumentError.new("#{filename}: no such file") unless File.file?(filename)
-    raise TruncatedFileError.new unless File.stat(filename).size >= 4
+    raise ArgumentError, "#{filename}: no such file" unless File.file?(filename)
+    raise TruncatedFileError unless File.stat(filename).size >= 4
 
     magic = File.open(filename, "rb") { |f| f.read(4) }.unpack("N").first
 
@@ -17,7 +17,7 @@ module MachO
     elsif Utils.magic?(magic)
       file = MachOFile.new(filename)
     else
-      raise MagicError.new(magic)
+      raise MagicError, magic
     end
 
     file

--- a/lib/macho/sections.rb
+++ b/lib/macho/sections.rb
@@ -45,7 +45,7 @@ module MachO
     :S_ATTR_DEBUG => 0x02000000,
     :S_ATTR_SOME_INSTRUCTIONS => 0x00000400,
     :S_ATTR_EXT_RELOC => 0x00000200,
-    :S_ATTR_LOC_RELOC => 0x00000100
+    :S_ATTR_LOC_RELOC => 0x00000100,
   }.freeze
 
   # association of section name symbols to names
@@ -62,7 +62,7 @@ module MachO
     :SECT_OBJC_STRINGS => "__selector_strs",
     :SECT_OBJC_REFS => "__selector_refs",
     :SECT_ICON_HEADER => "__header",
-    :SECT_ICON_TIFF => "__tiff"
+    :SECT_ICON_TIFF => "__tiff",
   }.freeze
 
   # Represents a section of a segment for 32-bit architectures.
@@ -101,14 +101,14 @@ module MachO
     attr_reader :reserved2
 
     # @see MachOStructure::FORMAT
-    FORMAT = "a16a16L=9"
+    FORMAT = "a16a16L=9".freeze
 
     # @see MachOStructure::SIZEOF
     SIZEOF = 68
 
     # @api private
     def initialize(sectname, segname, addr, size, offset, align, reloff,
-        nreloc, flags, reserved1, reserved2)
+                   nreloc, flags, reserved1, reserved2)
       @sectname = sectname
       @segname = segname
       @addr = addr
@@ -124,12 +124,17 @@ module MachO
 
     # @return [String] the section's name, with any trailing NULL characters removed
     def section_name
-      @sectname.delete("\x00")
+      sectname.delete("\x00")
     end
 
     # @return [String] the parent segment's name, with any trailing NULL characters removed
     def segment_name
-      @segname.delete("\x00")
+      segname.delete("\x00")
+    end
+
+    # @return [Boolean] true if the section has no contents (i.e, `size` is 0)
+    def empty?
+      size.zero?
     end
 
     # @example
@@ -149,14 +154,14 @@ module MachO
     attr_reader :reserved3
 
     # @see MachOStructure::FORMAT
-    FORMAT = "a16a16Q=2L=8"
+    FORMAT = "a16a16Q=2L=8".freeze
 
     # @see MachOStructure::SIZEOF
     SIZEOF = 80
 
     # @api private
     def initialize(sectname, segname, addr, size, offset, align, reloff,
-        nreloc, flags, reserved1, reserved2, reserved3)
+                   nreloc, flags, reserved1, reserved2, reserved3)
       super(sectname, segname, addr, size, offset, align, reloff,
         nreloc, flags, reserved1, reserved2)
       @reserved3 = reserved3

--- a/lib/macho/structure.rb
+++ b/lib/macho/structure.rb
@@ -5,7 +5,7 @@ module MachO
     # The String#unpack format of the data structure.
     # @return [String] the unpacking format
     # @api private
-    FORMAT = ""
+    FORMAT = "".freeze
 
     # The size of the data structure, in bytes.
     # @return [Fixnum] the size, in bytes
@@ -24,7 +24,7 @@ module MachO
     def self.new_from_bin(endianness, bin)
       format = Utils.specialize_format(self::FORMAT, endianness)
 
-      self.new(*bin.unpack(format))
+      new(*bin.unpack(format))
     end
   end
 end

--- a/lib/macho/utils.rb
+++ b/lib/macho/utils.rb
@@ -26,7 +26,7 @@ module MachO
     # @param endianness [Symbol] either `:big` or `:little`
     # @return [String] the converted string
     def self.specialize_format(format, endianness)
-      modifier = (endianness == :big) ? ">" : "<"
+      modifier = endianness == :big ? ">" : "<"
       format.tr("=", modifier)
     end
 
@@ -55,7 +55,7 @@ module MachO
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid Mach-O magic number, false otherwise
     def self.magic?(num)
-      MH_MAGICS.has_key?(num)
+      MH_MAGICS.key?(num)
     end
 
     # Compares the given number to valid Fat magic numbers.


### PR DESCRIPTION
Another low-priority PR, just cleans up the code a bit and adds a `.rubocop.yml` for future style enforcement.

`rubocop` complains about roughly 100 other things in the `lib/` tree, although most of them are even less significant (methods over 10 lines, for example).
All of the unresolved violations are here: [ruby-macho-rubocop.txt](https://github.com/Homebrew/ruby-macho/files/392754/ruby-macho-rubocop.txt)

cc @UniqMartin 