### PR TITLE
Deprecate MachOFile#sections in favor of SegmentCommand#sections.

### DIFF
--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -414,28 +414,9 @@ module MachO
     # @param segment [MachO::SegmentCommand, MachO::SegmentCommand64] the segment being inspected
     # @return [Array<MachO::Section>] if the Mach-O is 32-bit
     # @return [Array<MachO::Section64>] if the Mach-O is 64-bit
+    # @deprecated use {MachO::SegmentCommand#sections} instead
     def sections(segment)
-      section_klass = case segment
-      when MachO::SegmentCommand
-        MachO::Section
-      when MachO::SegmentCommand64
-        MachO::Section64
-      else
-        raise ArgumentError.new("not a valid segment")
-      end
-
-      sections = []
-      return sections if segment.nsects.zero?
-
-      offset = segment.view.offset + segment.class.bytesize
-
-      segment.nsects.times do
-        section_bin = @raw_data[offset, section_klass.bytesize]
-        sections << section_klass.new_from_bin(endianness, section_bin)
-        offset += section_klass.bytesize
-      end
-
-      sections
+      segment.sections
     end
 
     # Write all Mach-O data to the given filename.
@@ -555,7 +536,7 @@ module MachO
       offset = @raw_data.size
 
       segments.each do |seg|
-        sections(seg).each do |sect|
+        seg.sections.each do |sect|
           next if sect.size == 0
           next if sect.flag?(:S_ZEROFILL)
           next if sect.flag?(:S_THREAD_LOCAL_ZEROFILL)

--- a/lib/macho/sections.rb
+++ b/lib/macho/sections.rb
@@ -91,7 +91,7 @@ module MachO
     # @return [Fixnum] the number of relocation entries
     attr_reader :nreloc
 
-    # @return [Fixnum] flags for type and addrributes of the section
+    # @return [Fixnum] flags for type and attributes of the section
     attr_reader :flags
 
     # @return [void] reserved (for offset or index)

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -35,7 +35,7 @@ class MachOFileTest < Minitest::Test
 
       file.load_commands.each do |lc|
         assert lc
-        assert_equal MachO::LoadCommand, lc.class.superclass
+        assert_kind_of MachO::LoadCommand, lc
         assert_kind_of Fixnum, lc.offset
         assert_kind_of Fixnum, lc.cmd
         assert_kind_of Fixnum, lc.cmdsize
@@ -103,7 +103,7 @@ class MachOFileTest < Minitest::Test
         assert_kind_of Fixnum, seg.flags
         refute seg.flag?(:THIS_IS_A_MADE_UP_FLAG)
 
-        sections = file.sections(seg)
+        sections = seg.sections
 
         assert_kind_of Array, sections
 


### PR DESCRIPTION
New code should always prefer `SegmentCommand#sections` over `MachOFile#sections`, as this better expresses the relationship between segments and their sections (and the parent Mach-O).

I'm leaving `MachOFile#sections` in for the time being (with a `@deprecated` warning), although all internal references to it have been removed. It might make sense to remove it before 1.0, though.

cc @UniqMartin 