### PR TITLE
[WIP] Constant Isolation

### DIFF
--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -1,587 +1,590 @@
 module MachO
-  # big-endian fat magic
-  # @api private
-  FAT_MAGIC = 0xcafebabe
-
-  # little-endian fat magic
-  # this is defined, but should never appear in ruby-macho code because
-  # fat headers are always big-endian and therefore always unpacked as such.
-  # @api private
-  FAT_CIGAM = 0xbebafeca
-
-  # 32-bit big-endian magic
-  # @api private
-  MH_MAGIC = 0xfeedface
-
-  # 32-bit little-endian magic
-  # @api private
-  MH_CIGAM = 0xcefaedfe
-
-  # 64-bit big-endian magic
-  # @api private
-  MH_MAGIC_64 = 0xfeedfacf
-
-  # 64-bit little-endian magic
-  # @api private
-  MH_CIGAM_64 = 0xcffaedfe
-
-  # association of magic numbers to string representations
-  # @api private
-  MH_MAGICS = {
-    FAT_MAGIC => "FAT_MAGIC",
-    MH_MAGIC => "MH_MAGIC",
-    MH_CIGAM => "MH_CIGAM",
-    MH_MAGIC_64 => "MH_MAGIC_64",
-    MH_CIGAM_64 => "MH_CIGAM_64",
-  }.freeze
-
-  # mask for CPUs with 64-bit architectures (when running a 64-bit ABI?)
-  # @api private
-  CPU_ARCH_ABI64 = 0x01000000
-
-  # any CPU (unused?)
-  # @api private
-  CPU_TYPE_ANY = -1
-
-  # m68k compatible CPUs
-  # @api private
-  CPU_TYPE_MC680X0 = 0x06
-
-  # i386 and later compatible CPUs
-  # @api private
-  CPU_TYPE_I386 = 0x07
-
-  # x86_64 (AMD64) compatible CPUs
-  # @api private
-  CPU_TYPE_X86_64 = (CPU_TYPE_I386 | CPU_ARCH_ABI64)
-
-  # 32-bit ARM compatible CPUs
-  # @api private
-  CPU_TYPE_ARM = 0x0c
-
-  # m88k compatible CPUs
-  # @api private
-  CPU_TYPE_MC88000 = 0xd
-
-  # 64-bit ARM compatible CPUs
-  # @api private
-  CPU_TYPE_ARM64 = (CPU_TYPE_ARM | CPU_ARCH_ABI64)
-
-  # PowerPC compatible CPUs
-  # @api private
-  CPU_TYPE_POWERPC = 0x12
-
-  # PowerPC64 compatible CPUs
-  # @api private
-  CPU_TYPE_POWERPC64 = (CPU_TYPE_POWERPC | CPU_ARCH_ABI64)
-
-  # association of cpu types to symbol representations
-  # @api private
-  CPU_TYPES = {
-    CPU_TYPE_ANY => :any,
-    CPU_TYPE_I386 => :i386,
-    CPU_TYPE_X86_64 => :x86_64,
-    CPU_TYPE_ARM => :arm,
-    CPU_TYPE_ARM64 => :arm64,
-    CPU_TYPE_POWERPC => :ppc,
-    CPU_TYPE_POWERPC64 => :ppc64,
-  }.freeze
-
-  # mask for CPU subtype capabilities
-  # @api private
-  CPU_SUBTYPE_MASK = 0xff000000
-
-  # 64-bit libraries (undocumented!)
-  # @see http://llvm.org/docs/doxygen/html/Support_2MachO_8h_source.html
-  # @api private
-  CPU_SUBTYPE_LIB64 = 0x80000000
-
-  # the lowest common sub-type for `CPU_TYPE_I386`
-  # @api private
-  CPU_SUBTYPE_I386 = 3
-
-  # the i486 sub-type for `CPU_TYPE_I386`
-  # @api private
-  CPU_SUBTYPE_486 = 4
-
-  # the i486SX sub-type for `CPU_TYPE_I386`
-  # @api private
-  CPU_SUBTYPE_486SX = 132
-
-  # the i586 (P5, Pentium) sub-type for `CPU_TYPE_I386`
-  # @api private
-  CPU_SUBTYPE_586 = 5
-
-  # @see CPU_SUBTYPE_586
-  # @api private
-  CPU_SUBTYPE_PENT = CPU_SUBTYPE_586
-
-  # the Pentium Pro (P6) sub-type for `CPU_TYPE_I386`
-  # @api private
-  CPU_SUBTYPE_PENTPRO = 22
-
-  # the Pentium II (P6, M3?) sub-type for `CPU_TYPE_I386`
-  # @api private
-  CPU_SUBTYPE_PENTII_M3 = 54
-
-  # the Pentium II (P6, M5?) sub-type for `CPU_TYPE_I386`
-  # @api private
-  CPU_SUBTYPE_PENTII_M5 = 86
-
-  # the Pentium 4 (Netburst) sub-type for `CPU_TYPE_I386`
-  # @api private
-  CPU_SUBTYPE_PENTIUM_4 = 10
-
-  # the lowest common sub-type for `CPU_TYPE_MC680X0`
-  # @api private
-  CPU_SUBTYPE_MC680X0_ALL = 1
-
-  # @see CPU_SUBTYPE_MC680X0_ALL
-  # @api private
-  CPU_SUBTYPE_MC68030 = CPU_SUBTYPE_MC680X0_ALL
-
-  # the 040 subtype for `CPU_TYPE_MC680X0`
-  # @api private
-  CPU_SUBTYPE_MC68040 = 2
-
-  # the 030 subtype for `CPU_TYPE_MC680X0`
-  # @api private
-  CPU_SUBTYPE_MC68030_ONLY = 3
-
-  # the lowest common sub-type for `CPU_TYPE_X86_64`
-  # @api private
-  CPU_SUBTYPE_X86_64_ALL = CPU_SUBTYPE_I386
-
-  # the Haskell sub-type for `CPU_TYPE_X86_64`
-  # @api private
-  CPU_SUBTYPE_X86_64_H = 8
-
-  # the lowest common sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_ALL = 0
-
-  # the v4t sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V4T = 5
-
-  # the v6 sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V6 = 6
-
-  # the v5 sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V5TEJ = 7
-
-  # the xscale (v5 family) sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_XSCALE = 8
-
-  # the v7 sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V7 = 9
-
-  # the v7f (Cortex A9) sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V7F = 10
-
-  # the v7s ("Swift") sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V7S = 11
-
-  # the v7k ("Kirkwood40") sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V7K = 12
-
-  # the v6m sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V6M = 14
-
-  # the v7m sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V7M = 15
-
-  # the v7em sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V7EM = 16
-
-  # the v8 sub-type for `CPU_TYPE_ARM`
-  # @api private
-  CPU_SUBTYPE_ARM_V8 = 13
-
-  # the lowest common sub-type for `CPU_TYPE_ARM64`
-  # @api private
-  CPU_SUBTYPE_ARM64_ALL = 0
-
-  # the v8 sub-type for `CPU_TYPE_ARM64`
-  # @api private
-  CPU_SUBTYPE_ARM64_V8 = 1
-
-  # the lowest common sub-type for `CPU_TYPE_MC88000`
-  # @api private
-  CPU_SUBTYPE_MC88000_ALL = 0
-
-  # @see CPU_SUBTYPE_MC88000_ALL
-  # @api private
-  CPU_SUBTYPE_MMAX_JPC = CPU_SUBTYPE_MC88000_ALL
-
-  # the 100 sub-type for `CPU_TYPE_MC88000`
-  # @api private
-  CPU_SUBTYPE_MC88100 = 1
-
-  # the 110 sub-type for `CPU_TYPE_MC88000`
-  # @api private
-  CPU_SUBTYPE_MC88110 = 2
-
-  # the lowest common sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_ALL = 0
-
-  # the 601 sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_601 = 1
-
-  # the 602 sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_602 = 2
-
-  # the 603 sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_603 = 3
-
-  # the 603e (G2) sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_603E = 4
-
-  # the 603ev sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_603EV = 5
-
-  # the 604 sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_604 = 6
-
-  # the 604e sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_604E = 7
-
-  # the 620 sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_620 = 8
-
-  # the 750 (G3) sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_750 = 9
-
-  # the 7400 (G4) sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_7400 = 10
-
-  # the 7450 (G4 "Voyager") sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_7450 = 11
-
-  # the 970 (G5) sub-type for `CPU_TYPE_POWERPC`
-  # @api private
-  CPU_SUBTYPE_POWERPC_970 = 100
-
-  # any CPU sub-type for CPU type `CPU_TYPE_POWERPC64`
-  # @api private
-  CPU_SUBTYPE_POWERPC64_ALL = CPU_SUBTYPE_POWERPC_ALL
-
-  # association of CPU types/subtype pairs to symbol representations in
-  # (very) roughly descending order of commonness
-  # @see https://opensource.apple.com/source/cctools/cctools-877.8/libstuff/arch.c
-  # @api private
-  CPU_SUBTYPES = {
-    CPU_TYPE_I386 => {
-      CPU_SUBTYPE_I386 => :i386,
-      CPU_SUBTYPE_486 => :i486,
-      CPU_SUBTYPE_486SX => :i486SX,
-      CPU_SUBTYPE_586 => :i586, # also "pentium" in arch(3)
-      CPU_SUBTYPE_PENTPRO => :i686, # also "pentpro" in arch(3)
-      CPU_SUBTYPE_PENTII_M3 => :pentIIm3,
-      CPU_SUBTYPE_PENTII_M5 => :pentIIm5,
-      CPU_SUBTYPE_PENTIUM_4 => :pentium4,
-    }.freeze,
-    CPU_TYPE_X86_64 => {
-      CPU_SUBTYPE_X86_64_ALL => :x86_64,
-      CPU_SUBTYPE_X86_64_H => :x86_64h,
-    }.freeze,
-    CPU_TYPE_ARM => {
-      CPU_SUBTYPE_ARM_ALL => :arm,
-      CPU_SUBTYPE_ARM_V4T => :armv4t,
-      CPU_SUBTYPE_ARM_V6 => :armv6,
-      CPU_SUBTYPE_ARM_V5TEJ => :armv5,
-      CPU_SUBTYPE_ARM_XSCALE => :xscale,
-      CPU_SUBTYPE_ARM_V7 => :armv7,
-      CPU_SUBTYPE_ARM_V7F => :armv7f,
-      CPU_SUBTYPE_ARM_V7S => :armv7s,
-      CPU_SUBTYPE_ARM_V7K => :armv7k,
-      CPU_SUBTYPE_ARM_V6M => :armv6m,
-      CPU_SUBTYPE_ARM_V7M => :armv7m,
-      CPU_SUBTYPE_ARM_V7EM => :armv7em,
-      CPU_SUBTYPE_ARM_V8 => :armv8,
-    }.freeze,
-    CPU_TYPE_ARM64 => {
-      CPU_SUBTYPE_ARM64_ALL => :arm64,
-      CPU_SUBTYPE_ARM64_V8 => :arm64v8,
-    }.freeze,
-    CPU_TYPE_POWERPC => {
-      CPU_SUBTYPE_POWERPC_ALL => :ppc,
-      CPU_SUBTYPE_POWERPC_601 => :ppc601,
-      CPU_SUBTYPE_POWERPC_603 => :ppc603,
-      CPU_SUBTYPE_POWERPC_603E => :ppc603e,
-      CPU_SUBTYPE_POWERPC_603EV => :ppc603ev,
-      CPU_SUBTYPE_POWERPC_604 => :ppc604,
-      CPU_SUBTYPE_POWERPC_604E => :ppc604e,
-      CPU_SUBTYPE_POWERPC_750 => :ppc750,
-      CPU_SUBTYPE_POWERPC_7400 => :ppc7400,
-      CPU_SUBTYPE_POWERPC_7450 => :ppc7450,
-      CPU_SUBTYPE_POWERPC_970 => :ppc970,
-    }.freeze,
-    CPU_TYPE_POWERPC64 => {
-      CPU_SUBTYPE_POWERPC64_ALL => :ppc64,
-      # apparently the only exception to the naming scheme
-      CPU_SUBTYPE_POWERPC_970 => :ppc970_64,
-    }.freeze,
-    CPU_TYPE_MC680X0 => {
-      CPU_SUBTYPE_MC680X0_ALL => :m68k,
-      CPU_SUBTYPE_MC68030 => :mc68030,
-      CPU_SUBTYPE_MC68040 => :mc68040,
-    },
-    CPU_TYPE_MC88000 => {
-      CPU_SUBTYPE_MC88000_ALL => :m88k,
-    },
-  }.freeze
-
-  # relocatable object file
-  # @api private
-  MH_OBJECT = 0x1
-
-  # demand paged executable file
-  # @api private
-  MH_EXECUTE = 0x2
-
-  # fixed VM shared library file
-  # @api private
-  MH_FVMLIB = 0x3
-
-  # core dump file
-  # @api private
-  MH_CORE = 0x4
-
-  # preloaded executable file
-  # @api private
-  MH_PRELOAD = 0x5
-
-  # dynamically bound shared library
-  # @api private
-  MH_DYLIB = 0x6
-
-  # dynamic link editor
-  # @api private
-  MH_DYLINKER = 0x7
-
-  # dynamically bound bundle file
-  # @api private
-  MH_BUNDLE = 0x8
-
-  # shared library stub for static linking only, no section contents
-  # @api private
-  MH_DYLIB_STUB = 0x9
-
-  # companion file with only debug sections
-  # @api private
-  MH_DSYM = 0xa
-
-  # x86_64 kexts
-  # @api private
-  MH_KEXT_BUNDLE = 0xb
-
-  # association of filetypes to Symbol representations
-  # @api private
-  MH_FILETYPES = {
-    MH_OBJECT => :object,
-    MH_EXECUTE => :execute,
-    MH_FVMLIB => :fvmlib,
-    MH_CORE => :core,
-    MH_PRELOAD => :preload,
-    MH_DYLIB => :dylib,
-    MH_DYLINKER => :dylinker,
-    MH_BUNDLE => :bundle,
-    MH_DYLIB_STUB => :dylib_stub,
-    MH_DSYM => :dsym,
-    MH_KEXT_BUNDLE => :kext_bundle,
-  }.freeze
-
-  # association of mach header flag symbols to values
-  # @api private
-  MH_FLAGS = {
-    :MH_NOUNDEFS => 0x1,
-    :MH_INCRLINK => 0x2,
-    :MH_DYLDLINK => 0x4,
-    :MH_BINDATLOAD => 0x8,
-    :MH_PREBOUND => 0x10,
-    :MH_SPLIT_SEGS => 0x20,
-    :MH_LAZY_INIT => 0x40,
-    :MH_TWOLEVEL => 0x80,
-    :MH_FORCE_FLAT => 0x100,
-    :MH_NOMULTIDEFS => 0x200,
-    :MH_NOPREFIXBINDING => 0x400,
-    :MH_PREBINDABLE => 0x800,
-    :MH_ALLMODSBOUND => 0x1000,
-    :MH_SUBSECTIONS_VIA_SYMBOLS => 0x2000,
-    :MH_CANONICAL => 0x4000,
-    :MH_WEAK_DEFINES => 0x8000,
-    :MH_BINDS_TO_WEAK => 0x10000,
-    :MH_ALLOW_STACK_EXECUTION => 0x20000,
-    :MH_ROOT_SAFE => 0x40000,
-    :MH_SETUID_SAFE => 0x80000,
-    :MH_NO_REEXPORTED_DYLIBS => 0x100000,
-    :MH_PIE => 0x200000,
-    :MH_DEAD_STRIPPABLE_DYLIB => 0x400000,
-    :MH_HAS_TLV_DESCRIPTORS => 0x800000,
-    :MH_NO_HEAP_EXECUTION => 0x1000000,
-    :MH_APP_EXTENSION_SAFE => 0x02000000,
-  }.freeze
-
-  # Fat binary header structure
-  # @see MachO::FatArch
-  class FatHeader < MachOStructure
-    # @return [Fixnum] the magic number of the header (and file)
-    attr_reader :magic
-
-    # @return [Fixnum] the number of fat architecture structures following the header
-    attr_reader :nfat_arch
-
-    # always big-endian
-    # @see MachOStructure::FORMAT
+  # Classes and constants for parsing the headers of Mach-O binaries.
+  module Headers
+    # big-endian fat magic
     # @api private
-    FORMAT = "N2".freeze
+    FAT_MAGIC = 0xcafebabe
 
-    # @see MachOStructure::SIZEOF
+    # little-endian fat magic
+    # this is defined, but should never appear in ruby-macho code because
+    # fat headers are always big-endian and therefore always unpacked as such.
     # @api private
-    SIZEOF = 8
+    FAT_CIGAM = 0xbebafeca
 
+    # 32-bit big-endian magic
     # @api private
-    def initialize(magic, nfat_arch)
-      @magic = magic
-      @nfat_arch = nfat_arch
-    end
-  end
+    MH_MAGIC = 0xfeedface
 
-  # Fat binary header architecture structure. A Fat binary has one or more of
-  # these, representing one or more internal Mach-O blobs.
-  # @see MachO::FatHeader
-  class FatArch < MachOStructure
-    # @return [Fixnum] the CPU type of the Mach-O
-    attr_reader :cputype
-
-    # @return [Fixnum] the CPU subtype of the Mach-O
-    attr_reader :cpusubtype
-
-    # @return [Fixnum] the file offset to the beginning of the Mach-O data
-    attr_reader :offset
-
-    # @return [Fixnum] the size, in bytes, of the Mach-O data
-    attr_reader :size
-
-    # @return [Fixnum] the alignment, as a power of 2
-    attr_reader :align
-
-    # always big-endian
-    # @see MachOStructure::FORMAT
+    # 32-bit little-endian magic
     # @api private
-    FORMAT = "N5".freeze
+    MH_CIGAM = 0xcefaedfe
 
-    # @see MachOStructure::SIZEOF
+    # 64-bit big-endian magic
     # @api private
-    SIZEOF = 20
+    MH_MAGIC_64 = 0xfeedfacf
 
+    # 64-bit little-endian magic
     # @api private
-    def initialize(cputype, cpusubtype, offset, size, align)
-      @cputype = cputype
-      @cpusubtype = cpusubtype
-      @offset = offset
-      @size = size
-      @align = align
-    end
-  end
+    MH_CIGAM_64 = 0xcffaedfe
 
-  # 32-bit Mach-O file header structure
-  class MachHeader < MachOStructure
-    # @return [Fixnum] the magic number
-    attr_reader :magic
-
-    # @return [Fixnum] the CPU type of the Mach-O
-    attr_reader :cputype
-
-    # @return [Fixnum] the CPU subtype of the Mach-O
-    attr_reader :cpusubtype
-
-    # @return [Fixnum] the file type of the Mach-O
-    attr_reader :filetype
-
-    # @return [Fixnum] the number of load commands in the Mach-O
-    attr_reader :ncmds
-
-    # @return [Fixnum] the size of all load commands, in bytes, in the Mach-O
-    attr_reader :sizeofcmds
-
-    # @return [Fixnum] the header flags associated with the Mach-O
-    attr_reader :flags
-
-    # @see MachOStructure::FORMAT
+    # association of magic numbers to string representations
     # @api private
-    FORMAT = "L=7".freeze
+    MH_MAGICS = {
+      FAT_MAGIC => "FAT_MAGIC",
+      MH_MAGIC => "MH_MAGIC",
+      MH_CIGAM => "MH_CIGAM",
+      MH_MAGIC_64 => "MH_MAGIC_64",
+      MH_CIGAM_64 => "MH_CIGAM_64",
+    }.freeze
 
-    # @see MachOStructure::SIZEOF
+    # mask for CPUs with 64-bit architectures (when running a 64-bit ABI?)
     # @api private
-    SIZEOF = 28
+    CPU_ARCH_ABI64 = 0x01000000
 
+    # any CPU (unused?)
     # @api private
-    def initialize(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds,
-                   flags)
-      @magic = magic
-      @cputype = cputype
-      # For now we're not interested in additional capability bits also to be
-      # found in the `cpusubtype` field. We only care about the CPU sub-type.
-      @cpusubtype = cpusubtype & ~CPU_SUBTYPE_MASK
-      @filetype = filetype
-      @ncmds = ncmds
-      @sizeofcmds = sizeofcmds
-      @flags = flags
+    CPU_TYPE_ANY = -1
+
+    # m68k compatible CPUs
+    # @api private
+    CPU_TYPE_MC680X0 = 0x06
+
+    # i386 and later compatible CPUs
+    # @api private
+    CPU_TYPE_I386 = 0x07
+
+    # x86_64 (AMD64) compatible CPUs
+    # @api private
+    CPU_TYPE_X86_64 = (CPU_TYPE_I386 | CPU_ARCH_ABI64)
+
+    # 32-bit ARM compatible CPUs
+    # @api private
+    CPU_TYPE_ARM = 0x0c
+
+    # m88k compatible CPUs
+    # @api private
+    CPU_TYPE_MC88000 = 0xd
+
+    # 64-bit ARM compatible CPUs
+    # @api private
+    CPU_TYPE_ARM64 = (CPU_TYPE_ARM | CPU_ARCH_ABI64)
+
+    # PowerPC compatible CPUs
+    # @api private
+    CPU_TYPE_POWERPC = 0x12
+
+    # PowerPC64 compatible CPUs
+    # @api private
+    CPU_TYPE_POWERPC64 = (CPU_TYPE_POWERPC | CPU_ARCH_ABI64)
+
+    # association of cpu types to symbol representations
+    # @api private
+    CPU_TYPES = {
+      CPU_TYPE_ANY => :any,
+      CPU_TYPE_I386 => :i386,
+      CPU_TYPE_X86_64 => :x86_64,
+      CPU_TYPE_ARM => :arm,
+      CPU_TYPE_ARM64 => :arm64,
+      CPU_TYPE_POWERPC => :ppc,
+      CPU_TYPE_POWERPC64 => :ppc64,
+    }.freeze
+
+    # mask for CPU subtype capabilities
+    # @api private
+    CPU_SUBTYPE_MASK = 0xff000000
+
+    # 64-bit libraries (undocumented!)
+    # @see http://llvm.org/docs/doxygen/html/Support_2MachO_8h_source.html
+    # @api private
+    CPU_SUBTYPE_LIB64 = 0x80000000
+
+    # the lowest common sub-type for `CPU_TYPE_I386`
+    # @api private
+    CPU_SUBTYPE_I386 = 3
+
+    # the i486 sub-type for `CPU_TYPE_I386`
+    # @api private
+    CPU_SUBTYPE_486 = 4
+
+    # the i486SX sub-type for `CPU_TYPE_I386`
+    # @api private
+    CPU_SUBTYPE_486SX = 132
+
+    # the i586 (P5, Pentium) sub-type for `CPU_TYPE_I386`
+    # @api private
+    CPU_SUBTYPE_586 = 5
+
+    # @see CPU_SUBTYPE_586
+    # @api private
+    CPU_SUBTYPE_PENT = CPU_SUBTYPE_586
+
+    # the Pentium Pro (P6) sub-type for `CPU_TYPE_I386`
+    # @api private
+    CPU_SUBTYPE_PENTPRO = 22
+
+    # the Pentium II (P6, M3?) sub-type for `CPU_TYPE_I386`
+    # @api private
+    CPU_SUBTYPE_PENTII_M3 = 54
+
+    # the Pentium II (P6, M5?) sub-type for `CPU_TYPE_I386`
+    # @api private
+    CPU_SUBTYPE_PENTII_M5 = 86
+
+    # the Pentium 4 (Netburst) sub-type for `CPU_TYPE_I386`
+    # @api private
+    CPU_SUBTYPE_PENTIUM_4 = 10
+
+    # the lowest common sub-type for `CPU_TYPE_MC680X0`
+    # @api private
+    CPU_SUBTYPE_MC680X0_ALL = 1
+
+    # @see CPU_SUBTYPE_MC680X0_ALL
+    # @api private
+    CPU_SUBTYPE_MC68030 = CPU_SUBTYPE_MC680X0_ALL
+
+    # the 040 subtype for `CPU_TYPE_MC680X0`
+    # @api private
+    CPU_SUBTYPE_MC68040 = 2
+
+    # the 030 subtype for `CPU_TYPE_MC680X0`
+    # @api private
+    CPU_SUBTYPE_MC68030_ONLY = 3
+
+    # the lowest common sub-type for `CPU_TYPE_X86_64`
+    # @api private
+    CPU_SUBTYPE_X86_64_ALL = CPU_SUBTYPE_I386
+
+    # the Haskell sub-type for `CPU_TYPE_X86_64`
+    # @api private
+    CPU_SUBTYPE_X86_64_H = 8
+
+    # the lowest common sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_ALL = 0
+
+    # the v4t sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V4T = 5
+
+    # the v6 sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V6 = 6
+
+    # the v5 sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V5TEJ = 7
+
+    # the xscale (v5 family) sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_XSCALE = 8
+
+    # the v7 sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V7 = 9
+
+    # the v7f (Cortex A9) sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V7F = 10
+
+    # the v7s ("Swift") sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V7S = 11
+
+    # the v7k ("Kirkwood40") sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V7K = 12
+
+    # the v6m sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V6M = 14
+
+    # the v7m sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V7M = 15
+
+    # the v7em sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V7EM = 16
+
+    # the v8 sub-type for `CPU_TYPE_ARM`
+    # @api private
+    CPU_SUBTYPE_ARM_V8 = 13
+
+    # the lowest common sub-type for `CPU_TYPE_ARM64`
+    # @api private
+    CPU_SUBTYPE_ARM64_ALL = 0
+
+    # the v8 sub-type for `CPU_TYPE_ARM64`
+    # @api private
+    CPU_SUBTYPE_ARM64_V8 = 1
+
+    # the lowest common sub-type for `CPU_TYPE_MC88000`
+    # @api private
+    CPU_SUBTYPE_MC88000_ALL = 0
+
+    # @see CPU_SUBTYPE_MC88000_ALL
+    # @api private
+    CPU_SUBTYPE_MMAX_JPC = CPU_SUBTYPE_MC88000_ALL
+
+    # the 100 sub-type for `CPU_TYPE_MC88000`
+    # @api private
+    CPU_SUBTYPE_MC88100 = 1
+
+    # the 110 sub-type for `CPU_TYPE_MC88000`
+    # @api private
+    CPU_SUBTYPE_MC88110 = 2
+
+    # the lowest common sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_ALL = 0
+
+    # the 601 sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_601 = 1
+
+    # the 602 sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_602 = 2
+
+    # the 603 sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_603 = 3
+
+    # the 603e (G2) sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_603E = 4
+
+    # the 603ev sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_603EV = 5
+
+    # the 604 sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_604 = 6
+
+    # the 604e sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_604E = 7
+
+    # the 620 sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_620 = 8
+
+    # the 750 (G3) sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_750 = 9
+
+    # the 7400 (G4) sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_7400 = 10
+
+    # the 7450 (G4 "Voyager") sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_7450 = 11
+
+    # the 970 (G5) sub-type for `CPU_TYPE_POWERPC`
+    # @api private
+    CPU_SUBTYPE_POWERPC_970 = 100
+
+    # any CPU sub-type for CPU type `CPU_TYPE_POWERPC64`
+    # @api private
+    CPU_SUBTYPE_POWERPC64_ALL = CPU_SUBTYPE_POWERPC_ALL
+
+    # association of CPU types/subtype pairs to symbol representations in
+    # (very) roughly descending order of commonness
+    # @see https://opensource.apple.com/source/cctools/cctools-877.8/libstuff/arch.c
+    # @api private
+    CPU_SUBTYPES = {
+      CPU_TYPE_I386 => {
+        CPU_SUBTYPE_I386 => :i386,
+        CPU_SUBTYPE_486 => :i486,
+        CPU_SUBTYPE_486SX => :i486SX,
+        CPU_SUBTYPE_586 => :i586, # also "pentium" in arch(3)
+        CPU_SUBTYPE_PENTPRO => :i686, # also "pentpro" in arch(3)
+        CPU_SUBTYPE_PENTII_M3 => :pentIIm3,
+        CPU_SUBTYPE_PENTII_M5 => :pentIIm5,
+        CPU_SUBTYPE_PENTIUM_4 => :pentium4,
+      }.freeze,
+      CPU_TYPE_X86_64 => {
+        CPU_SUBTYPE_X86_64_ALL => :x86_64,
+        CPU_SUBTYPE_X86_64_H => :x86_64h,
+      }.freeze,
+      CPU_TYPE_ARM => {
+        CPU_SUBTYPE_ARM_ALL => :arm,
+        CPU_SUBTYPE_ARM_V4T => :armv4t,
+        CPU_SUBTYPE_ARM_V6 => :armv6,
+        CPU_SUBTYPE_ARM_V5TEJ => :armv5,
+        CPU_SUBTYPE_ARM_XSCALE => :xscale,
+        CPU_SUBTYPE_ARM_V7 => :armv7,
+        CPU_SUBTYPE_ARM_V7F => :armv7f,
+        CPU_SUBTYPE_ARM_V7S => :armv7s,
+        CPU_SUBTYPE_ARM_V7K => :armv7k,
+        CPU_SUBTYPE_ARM_V6M => :armv6m,
+        CPU_SUBTYPE_ARM_V7M => :armv7m,
+        CPU_SUBTYPE_ARM_V7EM => :armv7em,
+        CPU_SUBTYPE_ARM_V8 => :armv8,
+      }.freeze,
+      CPU_TYPE_ARM64 => {
+        CPU_SUBTYPE_ARM64_ALL => :arm64,
+        CPU_SUBTYPE_ARM64_V8 => :arm64v8,
+      }.freeze,
+      CPU_TYPE_POWERPC => {
+        CPU_SUBTYPE_POWERPC_ALL => :ppc,
+        CPU_SUBTYPE_POWERPC_601 => :ppc601,
+        CPU_SUBTYPE_POWERPC_603 => :ppc603,
+        CPU_SUBTYPE_POWERPC_603E => :ppc603e,
+        CPU_SUBTYPE_POWERPC_603EV => :ppc603ev,
+        CPU_SUBTYPE_POWERPC_604 => :ppc604,
+        CPU_SUBTYPE_POWERPC_604E => :ppc604e,
+        CPU_SUBTYPE_POWERPC_750 => :ppc750,
+        CPU_SUBTYPE_POWERPC_7400 => :ppc7400,
+        CPU_SUBTYPE_POWERPC_7450 => :ppc7450,
+        CPU_SUBTYPE_POWERPC_970 => :ppc970,
+      }.freeze,
+      CPU_TYPE_POWERPC64 => {
+        CPU_SUBTYPE_POWERPC64_ALL => :ppc64,
+        # apparently the only exception to the naming scheme
+        CPU_SUBTYPE_POWERPC_970 => :ppc970_64,
+      }.freeze,
+      CPU_TYPE_MC680X0 => {
+        CPU_SUBTYPE_MC680X0_ALL => :m68k,
+        CPU_SUBTYPE_MC68030 => :mc68030,
+        CPU_SUBTYPE_MC68040 => :mc68040,
+      },
+      CPU_TYPE_MC88000 => {
+        CPU_SUBTYPE_MC88000_ALL => :m88k,
+      },
+    }.freeze
+
+    # relocatable object file
+    # @api private
+    MH_OBJECT = 0x1
+
+    # demand paged executable file
+    # @api private
+    MH_EXECUTE = 0x2
+
+    # fixed VM shared library file
+    # @api private
+    MH_FVMLIB = 0x3
+
+    # core dump file
+    # @api private
+    MH_CORE = 0x4
+
+    # preloaded executable file
+    # @api private
+    MH_PRELOAD = 0x5
+
+    # dynamically bound shared library
+    # @api private
+    MH_DYLIB = 0x6
+
+    # dynamic link editor
+    # @api private
+    MH_DYLINKER = 0x7
+
+    # dynamically bound bundle file
+    # @api private
+    MH_BUNDLE = 0x8
+
+    # shared library stub for static linking only, no section contents
+    # @api private
+    MH_DYLIB_STUB = 0x9
+
+    # companion file with only debug sections
+    # @api private
+    MH_DSYM = 0xa
+
+    # x86_64 kexts
+    # @api private
+    MH_KEXT_BUNDLE = 0xb
+
+    # association of filetypes to Symbol representations
+    # @api private
+    MH_FILETYPES = {
+      MH_OBJECT => :object,
+      MH_EXECUTE => :execute,
+      MH_FVMLIB => :fvmlib,
+      MH_CORE => :core,
+      MH_PRELOAD => :preload,
+      MH_DYLIB => :dylib,
+      MH_DYLINKER => :dylinker,
+      MH_BUNDLE => :bundle,
+      MH_DYLIB_STUB => :dylib_stub,
+      MH_DSYM => :dsym,
+      MH_KEXT_BUNDLE => :kext_bundle,
+    }.freeze
+
+    # association of mach header flag symbols to values
+    # @api private
+    MH_FLAGS = {
+      :MH_NOUNDEFS => 0x1,
+      :MH_INCRLINK => 0x2,
+      :MH_DYLDLINK => 0x4,
+      :MH_BINDATLOAD => 0x8,
+      :MH_PREBOUND => 0x10,
+      :MH_SPLIT_SEGS => 0x20,
+      :MH_LAZY_INIT => 0x40,
+      :MH_TWOLEVEL => 0x80,
+      :MH_FORCE_FLAT => 0x100,
+      :MH_NOMULTIDEFS => 0x200,
+      :MH_NOPREFIXBINDING => 0x400,
+      :MH_PREBINDABLE => 0x800,
+      :MH_ALLMODSBOUND => 0x1000,
+      :MH_SUBSECTIONS_VIA_SYMBOLS => 0x2000,
+      :MH_CANONICAL => 0x4000,
+      :MH_WEAK_DEFINES => 0x8000,
+      :MH_BINDS_TO_WEAK => 0x10000,
+      :MH_ALLOW_STACK_EXECUTION => 0x20000,
+      :MH_ROOT_SAFE => 0x40000,
+      :MH_SETUID_SAFE => 0x80000,
+      :MH_NO_REEXPORTED_DYLIBS => 0x100000,
+      :MH_PIE => 0x200000,
+      :MH_DEAD_STRIPPABLE_DYLIB => 0x400000,
+      :MH_HAS_TLV_DESCRIPTORS => 0x800000,
+      :MH_NO_HEAP_EXECUTION => 0x1000000,
+      :MH_APP_EXTENSION_SAFE => 0x02000000,
+    }.freeze
+
+    # Fat binary header structure
+    # @see MachO::FatArch
+    class FatHeader < MachOStructure
+      # @return [Fixnum] the magic number of the header (and file)
+      attr_reader :magic
+
+      # @return [Fixnum] the number of fat architecture structures following the header
+      attr_reader :nfat_arch
+
+      # always big-endian
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "N2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 8
+
+      # @api private
+      def initialize(magic, nfat_arch)
+        @magic = magic
+        @nfat_arch = nfat_arch
+      end
     end
 
-    # @example
-    #  puts "this mach-o has position-independent execution" if header.flag?(:MH_PIE)
-    # @param flag [Symbol] a mach header flag symbol
-    # @return [Boolean] true if `flag` is present in the header's flag section
-    def flag?(flag)
-      flag = MH_FLAGS[flag]
-      return false if flag.nil?
-      flags & flag == flag
+    # Fat binary header architecture structure. A Fat binary has one or more of
+    # these, representing one or more internal Mach-O blobs.
+    # @see MachO::Headers::FatHeader
+    class FatArch < MachOStructure
+      # @return [Fixnum] the CPU type of the Mach-O
+      attr_reader :cputype
+
+      # @return [Fixnum] the CPU subtype of the Mach-O
+      attr_reader :cpusubtype
+
+      # @return [Fixnum] the file offset to the beginning of the Mach-O data
+      attr_reader :offset
+
+      # @return [Fixnum] the size, in bytes, of the Mach-O data
+      attr_reader :size
+
+      # @return [Fixnum] the alignment, as a power of 2
+      attr_reader :align
+
+      # always big-endian
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "N5".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 20
+
+      # @api private
+      def initialize(cputype, cpusubtype, offset, size, align)
+        @cputype = cputype
+        @cpusubtype = cpusubtype
+        @offset = offset
+        @size = size
+        @align = align
+      end
     end
-  end
 
-  # 64-bit Mach-O file header structure
-  class MachHeader64 < MachHeader
-    # @return [void]
-    attr_reader :reserved
+    # 32-bit Mach-O file header structure
+    class MachHeader < MachOStructure
+      # @return [Fixnum] the magic number
+      attr_reader :magic
 
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=8".freeze
+      # @return [Fixnum] the CPU type of the Mach-O
+      attr_reader :cputype
 
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 32
+      # @return [Fixnum] the CPU subtype of the Mach-O
+      attr_reader :cpusubtype
 
-    # @api private
-    def initialize(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds,
-                   flags, reserved)
-      super(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags)
-      @reserved = reserved
+      # @return [Fixnum] the file type of the Mach-O
+      attr_reader :filetype
+
+      # @return [Fixnum] the number of load commands in the Mach-O
+      attr_reader :ncmds
+
+      # @return [Fixnum] the size of all load commands, in bytes, in the Mach-O
+      attr_reader :sizeofcmds
+
+      # @return [Fixnum] the header flags associated with the Mach-O
+      attr_reader :flags
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=7".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 28
+
+      # @api private
+      def initialize(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds,
+                     flags)
+        @magic = magic
+        @cputype = cputype
+        # For now we're not interested in additional capability bits also to be
+        # found in the `cpusubtype` field. We only care about the CPU sub-type.
+        @cpusubtype = cpusubtype & ~CPU_SUBTYPE_MASK
+        @filetype = filetype
+        @ncmds = ncmds
+        @sizeofcmds = sizeofcmds
+        @flags = flags
+      end
+
+      # @example
+      #  puts "this mach-o has position-independent execution" if header.flag?(:MH_PIE)
+      # @param flag [Symbol] a mach header flag symbol
+      # @return [Boolean] true if `flag` is present in the header's flag section
+      def flag?(flag)
+        flag = MH_FLAGS[flag]
+        return false if flag.nil?
+        flags & flag == flag
+      end
+    end
+
+    # 64-bit Mach-O file header structure
+    class MachHeader64 < MachHeader
+      # @return [void]
+      attr_reader :reserved
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=8".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 32
+
+      # @api private
+      def initialize(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds,
+                     flags, reserved)
+        super(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags)
+        @reserved = reserved
+      end
     end
   end
 end

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -1,1314 +1,1317 @@
 module MachO
-  # load commands added after OS X 10.1 need to be bitwise ORed with
-  # LC_REQ_DYLD to be recognized by the dynamic linder (dyld)
-  # @api private
-  LC_REQ_DYLD = 0x80000000
-
-  # association of load commands to symbol representations
-  # @api private
-  LOAD_COMMANDS = {
-    0x1 => :LC_SEGMENT,
-    0x2 => :LC_SYMTAB,
-    0x3 => :LC_SYMSEG,
-    0x4 => :LC_THREAD,
-    0x5 => :LC_UNIXTHREAD,
-    0x6 => :LC_LOADFVMLIB,
-    0x7 => :LC_IDFVMLIB,
-    0x8 => :LC_IDENT,
-    0x9 => :LC_FVMFILE,
-    0xa => :LC_PREPAGE,
-    0xb => :LC_DYSYMTAB,
-    0xc => :LC_LOAD_DYLIB,
-    0xd => :LC_ID_DYLIB,
-    0xe => :LC_LOAD_DYLINKER,
-    0xf => :LC_ID_DYLINKER,
-    0x10 => :LC_PREBOUND_DYLIB,
-    0x11 => :LC_ROUTINES,
-    0x12 => :LC_SUB_FRAMEWORK,
-    0x13 => :LC_SUB_UMBRELLA,
-    0x14 => :LC_SUB_CLIENT,
-    0x15 => :LC_SUB_LIBRARY,
-    0x16 => :LC_TWOLEVEL_HINTS,
-    0x17 => :LC_PREBIND_CKSUM,
-    (0x18 | LC_REQ_DYLD) => :LC_LOAD_WEAK_DYLIB,
-    0x19 => :LC_SEGMENT_64,
-    0x1a => :LC_ROUTINES_64,
-    0x1b => :LC_UUID,
-    (0x1c | LC_REQ_DYLD) => :LC_RPATH,
-    0x1d => :LC_CODE_SIGNATURE,
-    0x1e => :LC_SEGMENT_SPLIT_INFO,
-    (0x1f | LC_REQ_DYLD) => :LC_REEXPORT_DYLIB,
-    0x20 => :LC_LAZY_LOAD_DYLIB,
-    0x21 => :LC_ENCRYPTION_INFO,
-    0x22 => :LC_DYLD_INFO,
-    (0x22 | LC_REQ_DYLD) => :LC_DYLD_INFO_ONLY,
-    (0x23 | LC_REQ_DYLD) => :LC_LOAD_UPWARD_DYLIB,
-    0x24 => :LC_VERSION_MIN_MACOSX,
-    0x25 => :LC_VERSION_MIN_IPHONEOS,
-    0x26 => :LC_FUNCTION_STARTS,
-    0x27 => :LC_DYLD_ENVIRONMENT,
-    (0x28 | LC_REQ_DYLD) => :LC_MAIN,
-    0x29 => :LC_DATA_IN_CODE,
-    0x2a => :LC_SOURCE_VERSION,
-    0x2b => :LC_DYLIB_CODE_SIGN_DRS,
-    0x2c => :LC_ENCRYPTION_INFO_64,
-    0x2d => :LC_LINKER_OPTION,
-    0x2e => :LC_LINKER_OPTIMIZATION_HINT,
-    0x2f => :LC_VERSION_MIN_TVOS,
-    0x30 => :LC_VERSION_MIN_WATCHOS,
-  }.freeze
-
-  # association of symbol representations to load command constants
-  # @api private
-  LOAD_COMMAND_CONSTANTS = LOAD_COMMANDS.invert.freeze
-
-  # load commands responsible for loading dylibs
-  # @api private
-  DYLIB_LOAD_COMMANDS = [
-    :LC_LOAD_DYLIB,
-    :LC_LOAD_WEAK_DYLIB,
-    :LC_REEXPORT_DYLIB,
-    :LC_LAZY_LOAD_DYLIB,
-    :LC_LOAD_UPWARD_DYLIB,
-  ].freeze
-
-  # load commands that can be created manually via {LoadCommand.create}
-  # @api private
-  CREATABLE_LOAD_COMMANDS = DYLIB_LOAD_COMMANDS + [
-    :LC_ID_DYLIB,
-    :LC_RPATH,
-    :LC_LOAD_DYLINKER,
-  ].freeze
-
-  # association of load command symbols to string representations of classes
-  # @api private
-  LC_STRUCTURES = {
-    :LC_SEGMENT => "SegmentCommand",
-    :LC_SYMTAB => "SymtabCommand",
-    :LC_SYMSEG => "SymsegCommand", # obsolete
-    :LC_THREAD => "ThreadCommand", # seems obsolete, but not documented as such
-    :LC_UNIXTHREAD => "ThreadCommand",
-    :LC_LOADFVMLIB => "FvmlibCommand", # obsolete
-    :LC_IDFVMLIB => "FvmlibCommand", # obsolete
-    :LC_IDENT => "IdentCommand", # obsolete
-    :LC_FVMFILE => "FvmfileCommand", # reserved for internal use only
-    :LC_PREPAGE => "LoadCommand", # reserved for internal use only, no public struct
-    :LC_DYSYMTAB => "DysymtabCommand",
-    :LC_LOAD_DYLIB => "DylibCommand",
-    :LC_ID_DYLIB => "DylibCommand",
-    :LC_LOAD_DYLINKER => "DylinkerCommand",
-    :LC_ID_DYLINKER => "DylinkerCommand",
-    :LC_PREBOUND_DYLIB => "PreboundDylibCommand",
-    :LC_ROUTINES => "RoutinesCommand",
-    :LC_SUB_FRAMEWORK => "SubFrameworkCommand",
-    :LC_SUB_UMBRELLA => "SubUmbrellaCommand",
-    :LC_SUB_CLIENT => "SubClientCommand",
-    :LC_SUB_LIBRARY => "SubLibraryCommand",
-    :LC_TWOLEVEL_HINTS => "TwolevelHintsCommand",
-    :LC_PREBIND_CKSUM => "PrebindCksumCommand",
-    :LC_LOAD_WEAK_DYLIB => "DylibCommand",
-    :LC_SEGMENT_64 => "SegmentCommand64",
-    :LC_ROUTINES_64 => "RoutinesCommand64",
-    :LC_UUID => "UUIDCommand",
-    :LC_RPATH => "RpathCommand",
-    :LC_CODE_SIGNATURE => "LinkeditDataCommand",
-    :LC_SEGMENT_SPLIT_INFO => "LinkeditDataCommand",
-    :LC_REEXPORT_DYLIB => "DylibCommand",
-    :LC_LAZY_LOAD_DYLIB => "DylibCommand",
-    :LC_ENCRYPTION_INFO => "EncryptionInfoCommand",
-    :LC_DYLD_INFO => "DyldInfoCommand",
-    :LC_DYLD_INFO_ONLY => "DyldInfoCommand",
-    :LC_LOAD_UPWARD_DYLIB => "DylibCommand",
-    :LC_VERSION_MIN_MACOSX => "VersionMinCommand",
-    :LC_VERSION_MIN_IPHONEOS => "VersionMinCommand",
-    :LC_FUNCTION_STARTS => "LinkeditDataCommand",
-    :LC_DYLD_ENVIRONMENT => "DylinkerCommand",
-    :LC_MAIN => "EntryPointCommand",
-    :LC_DATA_IN_CODE => "LinkeditDataCommand",
-    :LC_SOURCE_VERSION => "SourceVersionCommand",
-    :LC_DYLIB_CODE_SIGN_DRS => "LinkeditDataCommand",
-    :LC_ENCRYPTION_INFO_64 => "EncryptionInfoCommand64",
-    :LC_LINKER_OPTION => "LinkerOptionCommand",
-    :LC_LINKER_OPTIMIZATION_HINT => "LinkeditDataCommand",
-    :LC_VERSION_MIN_TVOS => "VersionMinCommand",
-    :LC_VERSION_MIN_WATCHOS => "VersionMinCommand",
-  }.freeze
-
-  # association of segment name symbols to names
-  # @api private
-  SEGMENT_NAMES = {
-    :SEG_PAGEZERO => "__PAGEZERO",
-    :SEG_TEXT => "__TEXT",
-    :SEG_DATA => "__DATA",
-    :SEG_OBJC => "__OBJC",
-    :SEG_ICON => "__ICON",
-    :SEG_LINKEDIT => "__LINKEDIT",
-    :SEG_UNIXSTACK => "__UNIXSTACK",
-    :SEG_IMPORT => "__IMPORT",
-  }.freeze
-
-  # association of segment flag symbols to values
-  # @api private
-  SEGMENT_FLAGS = {
-    :SG_HIGHVM => 0x1,
-    :SG_FVMLIB => 0x2,
-    :SG_NORELOC => 0x4,
-    :SG_PROTECTED_VERSION_1 => 0x8,
-  }.freeze
-
-  # Mach-O load command structure
-  # This is the most generic load command - only cmd ID and size are
-  # represented, and no actual data. Used when a more specific class
-  # isn't available/implemented.
-  class LoadCommand < MachOStructure
-    # @return [MachO::MachOView] the raw view associated with the load command
-    attr_reader :view
-
-    # @return [Fixnum] the load command's identifying number
-    attr_reader :cmd
-
-    # @return [Fixnum] the size of the load command, in bytes
-    attr_reader :cmdsize
-
-    # @see MachOStructure::FORMAT
+  # Classes and constants for parsing load commands in Mach-O binaries.
+  module LoadCommands
+    # load commands added after OS X 10.1 need to be bitwise ORed with
+    # LC_REQ_DYLD to be recognized by the dynamic linder (dyld)
     # @api private
-    FORMAT = "L=2".freeze
+    LC_REQ_DYLD = 0x80000000
 
-    # @see MachOStructure::SIZEOF
+    # association of load commands to symbol representations
     # @api private
-    SIZEOF = 8
+    LOAD_COMMANDS = {
+      0x1 => :LC_SEGMENT,
+      0x2 => :LC_SYMTAB,
+      0x3 => :LC_SYMSEG,
+      0x4 => :LC_THREAD,
+      0x5 => :LC_UNIXTHREAD,
+      0x6 => :LC_LOADFVMLIB,
+      0x7 => :LC_IDFVMLIB,
+      0x8 => :LC_IDENT,
+      0x9 => :LC_FVMFILE,
+      0xa => :LC_PREPAGE,
+      0xb => :LC_DYSYMTAB,
+      0xc => :LC_LOAD_DYLIB,
+      0xd => :LC_ID_DYLIB,
+      0xe => :LC_LOAD_DYLINKER,
+      0xf => :LC_ID_DYLINKER,
+      0x10 => :LC_PREBOUND_DYLIB,
+      0x11 => :LC_ROUTINES,
+      0x12 => :LC_SUB_FRAMEWORK,
+      0x13 => :LC_SUB_UMBRELLA,
+      0x14 => :LC_SUB_CLIENT,
+      0x15 => :LC_SUB_LIBRARY,
+      0x16 => :LC_TWOLEVEL_HINTS,
+      0x17 => :LC_PREBIND_CKSUM,
+      (0x18 | LC_REQ_DYLD) => :LC_LOAD_WEAK_DYLIB,
+      0x19 => :LC_SEGMENT_64,
+      0x1a => :LC_ROUTINES_64,
+      0x1b => :LC_UUID,
+      (0x1c | LC_REQ_DYLD) => :LC_RPATH,
+      0x1d => :LC_CODE_SIGNATURE,
+      0x1e => :LC_SEGMENT_SPLIT_INFO,
+      (0x1f | LC_REQ_DYLD) => :LC_REEXPORT_DYLIB,
+      0x20 => :LC_LAZY_LOAD_DYLIB,
+      0x21 => :LC_ENCRYPTION_INFO,
+      0x22 => :LC_DYLD_INFO,
+      (0x22 | LC_REQ_DYLD) => :LC_DYLD_INFO_ONLY,
+      (0x23 | LC_REQ_DYLD) => :LC_LOAD_UPWARD_DYLIB,
+      0x24 => :LC_VERSION_MIN_MACOSX,
+      0x25 => :LC_VERSION_MIN_IPHONEOS,
+      0x26 => :LC_FUNCTION_STARTS,
+      0x27 => :LC_DYLD_ENVIRONMENT,
+      (0x28 | LC_REQ_DYLD) => :LC_MAIN,
+      0x29 => :LC_DATA_IN_CODE,
+      0x2a => :LC_SOURCE_VERSION,
+      0x2b => :LC_DYLIB_CODE_SIGN_DRS,
+      0x2c => :LC_ENCRYPTION_INFO_64,
+      0x2d => :LC_LINKER_OPTION,
+      0x2e => :LC_LINKER_OPTIMIZATION_HINT,
+      0x2f => :LC_VERSION_MIN_TVOS,
+      0x30 => :LC_VERSION_MIN_WATCHOS,
+    }.freeze
 
-    # Instantiates a new LoadCommand given a view into its origin Mach-O
-    # @param view [MachO::MachOView] the load command's raw view
-    # @return [MachO::LoadCommand] the new load command
+    # association of symbol representations to load command constants
     # @api private
-    def self.new_from_bin(view)
-      bin = view.raw_data.slice(view.offset, bytesize)
-      format = Utils.specialize_format(self::FORMAT, view.endianness)
+    LOAD_COMMAND_CONSTANTS = LOAD_COMMANDS.invert.freeze
 
-      new(view, *bin.unpack(format))
-    end
-
-    # Creates a new (viewless) command corresponding to the symbol provided
-    # @param cmd_sym [Symbol] the symbol of the load command being created
-    # @param args [Array] the arguments for the load command being created
-    def self.create(cmd_sym, *args)
-      raise LoadCommandNotCreatableError, cmd_sym unless CREATABLE_LOAD_COMMANDS.include?(cmd_sym)
-
-      klass = MachO.const_get LC_STRUCTURES[cmd_sym]
-      cmd = LOAD_COMMAND_CONSTANTS[cmd_sym]
-
-      # cmd will be filled in, view and cmdsize will be left unpopulated
-      klass_arity = klass.instance_method(:initialize).arity - 3
-
-      raise LoadCommandCreationArityError.new(cmd_sym, klass_arity, args.size) if klass_arity != args.size
-
-      klass.new(nil, cmd, nil, *args)
-    end
-
-    # @param view [MachO::MachOView] the load command's raw view
-    # @param cmd [Fixnum] the load command's identifying number
-    # @param cmdsize [Fixnum] the size of the load command in bytes
+    # load commands responsible for loading dylibs
     # @api private
-    def initialize(view, cmd, cmdsize)
-      @view = view
-      @cmd = cmd
-      @cmdsize = cmdsize
-    end
+    DYLIB_LOAD_COMMANDS = [
+      :LC_LOAD_DYLIB,
+      :LC_LOAD_WEAK_DYLIB,
+      :LC_REEXPORT_DYLIB,
+      :LC_LAZY_LOAD_DYLIB,
+      :LC_LOAD_UPWARD_DYLIB,
+    ].freeze
 
-    # @return [Boolean] true if the load command can be serialized, false otherwise
-    def serializable?
-      CREATABLE_LOAD_COMMANDS.include?(LOAD_COMMANDS[cmd])
-    end
-
-    # @param context [MachO::LoadCommand::SerializationContext] the context
-    #  to serialize into
-    # @return [String, nil] the serialized fields of the load command, or nil
-    #  if the load command can't be serialized
+    # load commands that can be created manually via {LoadCommand.create}
     # @api private
-    def serialize(context)
-      raise LoadCommandNotSerializableError, LOAD_COMMANDS[cmd] unless serializable?
-      format = Utils.specialize_format(FORMAT, context.endianness)
-      [cmd, SIZEOF].pack(format)
-    end
+    CREATABLE_LOAD_COMMANDS = DYLIB_LOAD_COMMANDS + [
+      :LC_ID_DYLIB,
+      :LC_RPATH,
+      :LC_LOAD_DYLINKER,
+    ].freeze
 
-    # @return [Fixnum] the load command's offset in the source file
-    # @deprecated use {#view} instead
-    def offset
-      view.offset
-    end
+    # association of load command symbols to string representations of classes
+    # @api private
+    LC_STRUCTURES = {
+      :LC_SEGMENT => "SegmentCommand",
+      :LC_SYMTAB => "SymtabCommand",
+      :LC_SYMSEG => "SymsegCommand", # obsolete
+      :LC_THREAD => "ThreadCommand", # seems obsolete, but not documented as such
+      :LC_UNIXTHREAD => "ThreadCommand",
+      :LC_LOADFVMLIB => "FvmlibCommand", # obsolete
+      :LC_IDFVMLIB => "FvmlibCommand", # obsolete
+      :LC_IDENT => "IdentCommand", # obsolete
+      :LC_FVMFILE => "FvmfileCommand", # reserved for internal use only
+      :LC_PREPAGE => "LoadCommand", # reserved for internal use only, no public struct
+      :LC_DYSYMTAB => "DysymtabCommand",
+      :LC_LOAD_DYLIB => "DylibCommand",
+      :LC_ID_DYLIB => "DylibCommand",
+      :LC_LOAD_DYLINKER => "DylinkerCommand",
+      :LC_ID_DYLINKER => "DylinkerCommand",
+      :LC_PREBOUND_DYLIB => "PreboundDylibCommand",
+      :LC_ROUTINES => "RoutinesCommand",
+      :LC_SUB_FRAMEWORK => "SubFrameworkCommand",
+      :LC_SUB_UMBRELLA => "SubUmbrellaCommand",
+      :LC_SUB_CLIENT => "SubClientCommand",
+      :LC_SUB_LIBRARY => "SubLibraryCommand",
+      :LC_TWOLEVEL_HINTS => "TwolevelHintsCommand",
+      :LC_PREBIND_CKSUM => "PrebindCksumCommand",
+      :LC_LOAD_WEAK_DYLIB => "DylibCommand",
+      :LC_SEGMENT_64 => "SegmentCommand64",
+      :LC_ROUTINES_64 => "RoutinesCommand64",
+      :LC_UUID => "UUIDCommand",
+      :LC_RPATH => "RpathCommand",
+      :LC_CODE_SIGNATURE => "LinkeditDataCommand",
+      :LC_SEGMENT_SPLIT_INFO => "LinkeditDataCommand",
+      :LC_REEXPORT_DYLIB => "DylibCommand",
+      :LC_LAZY_LOAD_DYLIB => "DylibCommand",
+      :LC_ENCRYPTION_INFO => "EncryptionInfoCommand",
+      :LC_DYLD_INFO => "DyldInfoCommand",
+      :LC_DYLD_INFO_ONLY => "DyldInfoCommand",
+      :LC_LOAD_UPWARD_DYLIB => "DylibCommand",
+      :LC_VERSION_MIN_MACOSX => "VersionMinCommand",
+      :LC_VERSION_MIN_IPHONEOS => "VersionMinCommand",
+      :LC_FUNCTION_STARTS => "LinkeditDataCommand",
+      :LC_DYLD_ENVIRONMENT => "DylinkerCommand",
+      :LC_MAIN => "EntryPointCommand",
+      :LC_DATA_IN_CODE => "LinkeditDataCommand",
+      :LC_SOURCE_VERSION => "SourceVersionCommand",
+      :LC_DYLIB_CODE_SIGN_DRS => "LinkeditDataCommand",
+      :LC_ENCRYPTION_INFO_64 => "EncryptionInfoCommand64",
+      :LC_LINKER_OPTION => "LinkerOptionCommand",
+      :LC_LINKER_OPTIMIZATION_HINT => "LinkeditDataCommand",
+      :LC_VERSION_MIN_TVOS => "VersionMinCommand",
+      :LC_VERSION_MIN_WATCHOS => "VersionMinCommand",
+    }.freeze
 
-    # @return [Symbol] a symbol representation of the load command's identifying number
-    def type
-      LOAD_COMMANDS[cmd]
-    end
+    # association of segment name symbols to names
+    # @api private
+    SEGMENT_NAMES = {
+      :SEG_PAGEZERO => "__PAGEZERO",
+      :SEG_TEXT => "__TEXT",
+      :SEG_DATA => "__DATA",
+      :SEG_OBJC => "__OBJC",
+      :SEG_ICON => "__ICON",
+      :SEG_LINKEDIT => "__LINKEDIT",
+      :SEG_UNIXSTACK => "__UNIXSTACK",
+      :SEG_IMPORT => "__IMPORT",
+    }.freeze
 
-    alias to_sym type
+    # association of segment flag symbols to values
+    # @api private
+    SEGMENT_FLAGS = {
+      :SG_HIGHVM => 0x1,
+      :SG_FVMLIB => 0x2,
+      :SG_NORELOC => 0x4,
+      :SG_PROTECTED_VERSION_1 => 0x8,
+    }.freeze
 
-    # @return [String] a string representation of the load command's identifying number
-    def to_s
-      type.to_s
-    end
+    # Mach-O load command structure
+    # This is the most generic load command - only cmd ID and size are
+    # represented, and no actual data. Used when a more specific class
+    # isn't available/implemented.
+    class LoadCommand < MachOStructure
+      # @return [MachO::MachOView] the raw view associated with the load command
+      attr_reader :view
 
-    # Represents a Load Command string. A rough analogue to the lc_str
-    # struct used internally by OS X. This class allows ruby-macho to
-    # pretend that strings stored in LCs are immediately available without
-    # explicit operations on the raw Mach-O data.
-    class LCStr
-      # @param lc [MachO::LoadCommand] the load command
-      # @param lc_str [Fixnum, String] the offset to the beginning of the string,
-      #  or the string itself if not being initialized with a view.
-      # @raise [MachO::LCStrMalformedError] if the string is malformed
-      # @todo devise a solution such that the `lc_str` parameter is not
-      #  interpreted differently depending on `lc.view`. The current behavior
-      #  is a hack to allow viewless load command creation.
+      # @return [Fixnum] the load command's identifying number
+      attr_reader :cmd
+
+      # @return [Fixnum] the size of the load command, in bytes
+      attr_reader :cmdsize
+
+      # @see MachOStructure::FORMAT
       # @api private
-      def initialize(lc, lc_str)
-        view = lc.view
+      FORMAT = "L=2".freeze
 
-        if view
-          lc_str_abs = view.offset + lc_str
-          lc_end = view.offset + lc.cmdsize - 1
-          raw_string = view.raw_data.slice(lc_str_abs..lc_end)
-          @string, null_byte, _padding = raw_string.partition("\x00")
-          raise LCStrMalformedError, lc if null_byte.empty?
-          @string_offset = lc_str
-        else
-          @string = lc_str
-          @string_offset = 0
-        end
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 8
+
+      # Instantiates a new LoadCommand given a view into its origin Mach-O
+      # @param view [MachO::MachOView] the load command's raw view
+      # @return [MachO::LoadCommands::LoadCommand] the new load command
+      # @api private
+      def self.new_from_bin(view)
+        bin = view.raw_data.slice(view.offset, bytesize)
+        format = Utils.specialize_format(self::FORMAT, view.endianness)
+
+        new(view, *bin.unpack(format))
       end
 
-      # @return [String] a string representation of the LCStr
+      # Creates a new (viewless) command corresponding to the symbol provided
+      # @param cmd_sym [Symbol] the symbol of the load command being created
+      # @param args [Array] the arguments for the load command being created
+      def self.create(cmd_sym, *args)
+        raise LoadCommandNotCreatableError, cmd_sym unless CREATABLE_LOAD_COMMANDS.include?(cmd_sym)
+
+        klass = LoadCommands.const_get LC_STRUCTURES[cmd_sym]
+        cmd = LOAD_COMMAND_CONSTANTS[cmd_sym]
+
+        # cmd will be filled in, view and cmdsize will be left unpopulated
+        klass_arity = klass.instance_method(:initialize).arity - 3
+
+        raise LoadCommandCreationArityError.new(cmd_sym, klass_arity, args.size) if klass_arity != args.size
+
+        klass.new(nil, cmd, nil, *args)
+      end
+
+      # @param view [MachO::MachOView] the load command's raw view
+      # @param cmd [Fixnum] the load command's identifying number
+      # @param cmdsize [Fixnum] the size of the load command in bytes
+      # @api private
+      def initialize(view, cmd, cmdsize)
+        @view = view
+        @cmd = cmd
+        @cmdsize = cmdsize
+      end
+
+      # @return [Boolean] true if the load command can be serialized, false otherwise
+      def serializable?
+        CREATABLE_LOAD_COMMANDS.include?(LOAD_COMMANDS[cmd])
+      end
+
+      # @param context [MachO::LoadCommands::LoadCommand::SerializationContext] the context
+      #  to serialize into
+      # @return [String, nil] the serialized fields of the load command, or nil
+      #  if the load command can't be serialized
+      # @api private
+      def serialize(context)
+        raise LoadCommandNotSerializableError, LOAD_COMMANDS[cmd] unless serializable?
+        format = Utils.specialize_format(FORMAT, context.endianness)
+        [cmd, SIZEOF].pack(format)
+      end
+
+      # @return [Fixnum] the load command's offset in the source file
+      # @deprecated use {#view} instead
+      def offset
+        view.offset
+      end
+
+      # @return [Symbol] a symbol representation of the load command's identifying number
+      def type
+        LOAD_COMMANDS[cmd]
+      end
+
+      alias to_sym type
+
+      # @return [String] a string representation of the load command's identifying number
       def to_s
-        @string
+        type.to_s
       end
 
-      # @return [Fixnum] the offset to the beginning of the string in the load command
-      def to_i
-        @string_offset
-      end
-    end
-
-    # Represents the contextual information needed by a load command to
-    # serialize itself correctly into a binary string.
-    class SerializationContext
-      # @return [Symbol] the endianness of the serialized load command
-      attr_reader :endianness
-
-      # @return [Fixnum] the constant alignment value used to pad the serialized load command
-      attr_reader :alignment
-
-      # @param macho [MachO::MachOFile] the file to contextualize
-      # @return [MachO::LoadCommand::SerializationContext] the resulting context
-      def self.context_for(macho)
-        new(macho.endianness, macho.alignment)
-      end
-
-      # @param endianness [Symbol] the endianness of the context
-      # @param alignment [Fixnum] the alignment of the context
-      # @api private
-      def initialize(endianness, alignment)
-        @endianness = endianness
-        @alignment = alignment
-      end
-    end
-  end
-
-  # A load command containing a single 128-bit unique random number identifying
-  # an object produced by static link editor. Corresponds to LC_UUID.
-  class UUIDCommand < LoadCommand
-    # @return [Array<Fixnum>] the UUID
-    attr_reader :uuid
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=2a16".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 24
-
-    # @api private
-    def initialize(view, cmd, cmdsize, uuid)
-      super(view, cmd, cmdsize)
-      @uuid = uuid.unpack("C16") # re-unpack for the actual UUID array
-    end
-
-    # @return [String] a string representation of the UUID
-    def uuid_string
-      hexes = uuid.map { |e| "%02x" % e }
-      segs = [
-        hexes[0..3].join, hexes[4..5].join, hexes[6..7].join,
-        hexes[8..9].join, hexes[10..15].join
-      ]
-
-      segs.join("-")
-    end
-  end
-
-  # A load command indicating that part of this file is to be mapped into
-  # the task's address space. Corresponds to LC_SEGMENT.
-  class SegmentCommand < LoadCommand
-    # @return [String] the name of the segment
-    attr_reader :segname
-
-    # @return [Fixnum] the memory address of the segment
-    attr_reader :vmaddr
-
-    # @return [Fixnum] the memory size of the segment
-    attr_reader :vmsize
-
-    # @return [Fixnum] the file offset of the segment
-    attr_reader :fileoff
-
-    # @return [Fixnum] the amount to map from the file
-    attr_reader :filesize
-
-    # @return [Fixnum] the maximum VM protection
-    attr_reader :maxprot
-
-    # @return [Fixnum] the initial VM protection
-    attr_reader :initprot
-
-    # @return [Fixnum] the number of sections in the segment
-    attr_reader :nsects
-
-    # @return [Fixnum] any flags associated with the segment
-    attr_reader :flags
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=2a16L=4l=2L=2".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 56
-
-    # @api private
-    def initialize(view, cmd, cmdsize, segname, vmaddr, vmsize, fileoff,
-                   filesize, maxprot, initprot, nsects, flags)
-      super(view, cmd, cmdsize)
-      @segname = segname.delete("\x00")
-      @vmaddr = vmaddr
-      @vmsize = vmsize
-      @fileoff = fileoff
-      @filesize = filesize
-      @maxprot = maxprot
-      @initprot = initprot
-      @nsects = nsects
-      @flags = flags
-    end
-
-    # All sections referenced within this segment.
-    # @return [Array<MachO::Section>] if the Mach-O is 32-bit
-    # @return [Array<MachO::Section64>] if the Mach-O is 64-bit
-    def sections
-      klass = case self
-      when MachO::SegmentCommand64
-        MachO::Section64
-      when MachO::SegmentCommand
-        MachO::Section
-      end
-
-      bins = view.raw_data[view.offset + self.class.bytesize, nsects * klass.bytesize]
-      bins.unpack("a#{klass.bytesize}" * nsects).map do |bin|
-        klass.new_from_bin(view.endianness, bin)
-      end
-    end
-
-    # @example
-    #  puts "this segment relocated in/to it" if sect.flag?(:SG_NORELOC)
-    # @param flag [Symbol] a segment flag symbol
-    # @return [Boolean] true if `flag` is present in the segment's flag field
-    def flag?(flag)
-      flag = SEGMENT_FLAGS[flag]
-      return false if flag.nil?
-      flags & flag == flag
-    end
-  end
-
-  # A load command indicating that part of this file is to be mapped into
-  # the task's address space. Corresponds to LC_SEGMENT_64.
-  class SegmentCommand64 < SegmentCommand
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=2a16Q=4l=2L=2".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 72
-  end
-
-  # A load command representing some aspect of shared libraries, depending
-  # on filetype. Corresponds to LC_ID_DYLIB, LC_LOAD_DYLIB, LC_LOAD_WEAK_DYLIB,
-  # and LC_REEXPORT_DYLIB.
-  class DylibCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the library's path name as an LCStr
-    attr_reader :name
-
-    # @return [Fixnum] the library's build time stamp
-    attr_reader :timestamp
-
-    # @return [Fixnum] the library's current version number
-    attr_reader :current_version
-
-    # @return [Fixnum] the library's compatibility version number
-    attr_reader :compatibility_version
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=6".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 24
-
-    # @api private
-    def initialize(view, cmd, cmdsize, name, timestamp, current_version, compatibility_version)
-      super(view, cmd, cmdsize)
-      @name = LCStr.new(self, name)
-      @timestamp = timestamp
-      @current_version = current_version
-      @compatibility_version = compatibility_version
-    end
-
-    # @param context [MachO::LoadCcommand::SerializationContext] the context
-    # @return [String] the serialized fields of the load command
-    # @api private
-    def serialize(context)
-      format = Utils.specialize_format(FORMAT, context.endianness)
-      string_payload, string_offsets = Utils.pack_strings(SIZEOF, context.alignment, :name => name.to_s)
-      cmdsize = SIZEOF + string_payload.bytesize
-      [cmd, cmdsize, string_offsets[:name], timestamp, current_version,
-       compatibility_version].pack(format) + string_payload
-    end
-  end
-
-  # A load command representing some aspect of the dynamic linker, depending
-  # on filetype. Corresponds to LC_ID_DYLINKER, LC_LOAD_DYLINKER, and
-  # LC_DYLD_ENVIRONMENT.
-  class DylinkerCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the dynamic linker's path name as an LCStr
-    attr_reader :name
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=3".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 12
-
-    # @api private
-    def initialize(view, cmd, cmdsize, name)
-      super(view, cmd, cmdsize)
-      @name = LCStr.new(self, name)
-    end
-
-    # @param context [MachO::LoadCcommand::SerializationContext] the context
-    # @return [String] the serialized fields of the load command
-    # @api private
-    def serialize(context)
-      format = Utils.specialize_format(FORMAT, context.endianness)
-      string_payload, string_offsets = Utils.pack_strings(SIZEOF, context.alignment, :name => name.to_s)
-      cmdsize = SIZEOF + string_payload.bytesize
-      [cmd, cmdsize, string_offsets[:name]].pack(format) + string_payload
-    end
-  end
-
-  # A load command used to indicate dynamic libraries used in prebinding.
-  # Corresponds to LC_PREBOUND_DYLIB.
-  class PreboundDylibCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the library's path name as an LCStr
-    attr_reader :name
-
-    # @return [Fixnum] the number of modules in the library
-    attr_reader :nmodules
-
-    # @return [Fixnum] a bit vector of linked modules
-    attr_reader :linked_modules
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=5".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 20
-
-    # @api private
-    def initialize(view, cmd, cmdsize, name, nmodules, linked_modules)
-      super(view, cmd, cmdsize)
-      @name = LCStr.new(self, name)
-      @nmodules = nmodules
-      @linked_modules = linked_modules
-    end
-  end
-
-  # A load command used to represent threads.
-  # @note cctools-870 has all fields of thread_command commented out except common ones (cmd, cmdsize)
-  class ThreadCommand < LoadCommand
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=2".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 8
-  end
-
-  # A load command containing the address of the dynamic shared library
-  # initialization routine and an index into the module table for the module
-  # that defines the routine. Corresponds to LC_ROUTINES.
-  class RoutinesCommand < LoadCommand
-    # @return [Fixnum] the address of the initialization routine
-    attr_reader :init_address
-
-    # @return [Fixnum] the index into the module table that the init routine is defined in
-    attr_reader :init_module
-
-    # @return [void]
-    attr_reader :reserved1
-
-    # @return [void]
-    attr_reader :reserved2
-
-    # @return [void]
-    attr_reader :reserved3
-
-    # @return [void]
-    attr_reader :reserved4
-
-    # @return [void]
-    attr_reader :reserved5
-
-    # @return [void]
-    attr_reader :reserved6
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=10".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 40
-
-    # @api private
-    def initialize(view, cmd, cmdsize, init_address, init_module, reserved1,
-                   reserved2, reserved3, reserved4, reserved5, reserved6)
-      super(view, cmd, cmdsize)
-      @init_address = init_address
-      @init_module = init_module
-      @reserved1 = reserved1
-      @reserved2 = reserved2
-      @reserved3 = reserved3
-      @reserved4 = reserved4
-      @reserved5 = reserved5
-      @reserved6 = reserved6
-    end
-  end
-
-  # A load command containing the address of the dynamic shared library
-  # initialization routine and an index into the module table for the module
-  # that defines the routine. Corresponds to LC_ROUTINES_64.
-  class RoutinesCommand64 < RoutinesCommand
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=2Q=8".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 72
-  end
-
-  # A load command signifying membership of a subframework containing the name
-  # of an umbrella framework. Corresponds to LC_SUB_FRAMEWORK.
-  class SubFrameworkCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the umbrella framework name as an LCStr
-    attr_reader :umbrella
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=3".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 12
-
-    # @api private
-    def initialize(view, cmd, cmdsize, umbrella)
-      super(view, cmd, cmdsize)
-      @umbrella = LCStr.new(self, umbrella)
-    end
-  end
-
-  # A load command signifying membership of a subumbrella containing the name
-  # of an umbrella framework. Corresponds to LC_SUB_UMBRELLA.
-  class SubUmbrellaCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the subumbrella framework name as an LCStr
-    attr_reader :sub_umbrella
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=3".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 12
-
-    # @api private
-    def initialize(view, cmd, cmdsize, sub_umbrella)
-      super(view, cmd, cmdsize)
-      @sub_umbrella = LCStr.new(self, sub_umbrella)
-    end
-  end
-
-  # A load command signifying a sublibrary of a shared library. Corresponds
-  # to LC_SUB_LIBRARY.
-  class SubLibraryCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the sublibrary name as an LCStr
-    attr_reader :sub_library
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=3".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 12
-
-    # @api private
-    def initialize(view, cmd, cmdsize, sub_library)
-      super(view, cmd, cmdsize)
-      @sub_library = LCStr.new(self, sub_library)
-    end
-  end
-
-  # A load command signifying a shared library that is a subframework of
-  # an umbrella framework. Corresponds to LC_SUB_CLIENT.
-  class SubClientCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the subclient name as an LCStr
-    attr_reader :sub_client
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=3".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 12
-
-    # @api private
-    def initialize(view, cmd, cmdsize, sub_client)
-      super(view, cmd, cmdsize)
-      @sub_client = LCStr.new(self, sub_client)
-    end
-  end
-
-  # A load command containing the offsets and sizes of the link-edit 4.3BSD
-  # "stab" style symbol table information. Corresponds to LC_SYMTAB.
-  class SymtabCommand < LoadCommand
-    # @return [Fixnum] the symbol table's offset
-    attr_reader :symoff
-
-    # @return [Fixnum] the number of symbol table entries
-    attr_reader :nsyms
-
-    # @return the string table's offset
-    attr_reader :stroff
-
-    # @return the string table size in bytes
-    attr_reader :strsize
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=6".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 24
-
-    # @api private
-    def initialize(view, cmd, cmdsize, symoff, nsyms, stroff, strsize)
-      super(view, cmd, cmdsize)
-      @symoff = symoff
-      @nsyms = nsyms
-      @stroff = stroff
-      @strsize = strsize
-    end
-  end
-
-  # A load command containing symbolic information needed to support data
-  # structures used by the dynamic link editor. Corresponds to LC_DYSYMTAB.
-  class DysymtabCommand < LoadCommand
-    # @return [Fixnum] the index to local symbols
-    attr_reader :ilocalsym
-
-    # @return [Fixnum] the number of local symbols
-    attr_reader :nlocalsym
-
-    # @return [Fixnum] the index to externally defined symbols
-    attr_reader :iextdefsym
-
-    # @return [Fixnum] the number of externally defined symbols
-    attr_reader :nextdefsym
-
-    # @return [Fixnum] the index to undefined symbols
-    attr_reader :iundefsym
-
-    # @return [Fixnum] the number of undefined symbols
-    attr_reader :nundefsym
-
-    # @return [Fixnum] the file offset to the table of contents
-    attr_reader :tocoff
-
-    # @return [Fixnum] the number of entries in the table of contents
-    attr_reader :ntoc
-
-    # @return [Fixnum] the file offset to the module table
-    attr_reader :modtaboff
-
-    # @return [Fixnum] the number of entries in the module table
-    attr_reader :nmodtab
-
-    # @return [Fixnum] the file offset to the referenced symbol table
-    attr_reader :extrefsymoff
-
-    # @return [Fixnum] the number of entries in the referenced symbol table
-    attr_reader :nextrefsyms
-
-    # @return [Fixnum] the file offset to the indirect symbol table
-    attr_reader :indirectsymoff
-
-    # @return [Fixnum] the number of entries in the indirect symbol table
-    attr_reader :nindirectsyms
-
-    # @return [Fixnum] the file offset to the external relocation entries
-    attr_reader :extreloff
-
-    # @return [Fixnum] the number of external relocation entries
-    attr_reader :nextrel
-
-    # @return [Fixnum] the file offset to the local relocation entries
-    attr_reader :locreloff
-
-    # @return [Fixnum] the number of local relocation entries
-    attr_reader :nlocrel
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=20".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 80
-
-    # ugh
-    # @api private
-    def initialize(view, cmd, cmdsize, ilocalsym, nlocalsym, iextdefsym,
-                   nextdefsym, iundefsym, nundefsym, tocoff, ntoc, modtaboff,
-                   nmodtab, extrefsymoff, nextrefsyms, indirectsymoff,
-                   nindirectsyms, extreloff, nextrel, locreloff, nlocrel)
-      super(view, cmd, cmdsize)
-      @ilocalsym = ilocalsym
-      @nlocalsym = nlocalsym
-      @iextdefsym = iextdefsym
-      @nextdefsym = nextdefsym
-      @iundefsym = iundefsym
-      @nundefsym = nundefsym
-      @tocoff = tocoff
-      @ntoc = ntoc
-      @modtaboff = modtaboff
-      @nmodtab = nmodtab
-      @extrefsymoff = extrefsymoff
-      @nextrefsyms = nextrefsyms
-      @indirectsymoff = indirectsymoff
-      @nindirectsyms = nindirectsyms
-      @extreloff = extreloff
-      @nextrel = nextrel
-      @locreloff = locreloff
-      @nlocrel = nlocrel
-    end
-  end
-
-  # A load command containing the offset and number of hints in the two-level
-  # namespace lookup hints table. Corresponds to LC_TWOLEVEL_HINTS.
-  class TwolevelHintsCommand < LoadCommand
-    # @return [Fixnum] the offset to the hint table
-    attr_reader :htoffset
-
-    # @return [Fixnum] the number of hints in the hint table
-    attr_reader :nhints
-
-    # @return [MachO::TwolevelHintsCommand::TwolevelHintTable] the hint table
-    attr_reader :table
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=4".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 16
-
-    # @api private
-    def initialize(view, cmd, cmdsize, htoffset, nhints)
-      super(view, cmd, cmdsize)
-      @htoffset = htoffset
-      @nhints = nhints
-      @table = TwolevelHintsTable.new(view, htoffset, nhints)
-    end
-
-    # A representation of the two-level namespace lookup hints table exposed
-    # by a {TwolevelHintsCommand} (`LC_TWOLEVEL_HINTS`).
-    class TwolevelHintsTable
-      # @return [Array<MachO::TwoLevelHintsTable::TwoLevelHint>] all hints in the table
-      attr_reader :hints
-
-      # @param view [MachO::MachOView] the view into the current Mach-O
-      # @param htoffset [Fixnum] the offset of the hints table
-      # @param nhints [Fixnum] the number of two-level hints in the table
-      # @api private
-      def initialize(view, htoffset, nhints)
-        format = Utils.specialize_format("L=#{nhints}", view.endianness)
-        raw_table = view.raw_data[htoffset, nhints * 4]
-        blobs = raw_table.unpack(format)
-
-        @hints = blobs.map { |b| TwolevelHint.new(b) }
-      end
-
-      # An individual two-level namespace lookup hint.
-      class TwolevelHint
-        # @return [Fixnum] the index into the sub-images
-        attr_reader :isub_image
-
-        # @return [Fixnum] the index into the table of contents
-        attr_reader :itoc
-
-        # @param blob [Fixnum] the 32-bit number containing the lookup hint
+      # Represents a Load Command string. A rough analogue to the lc_str
+      # struct used internally by OS X. This class allows ruby-macho to
+      # pretend that strings stored in LCs are immediately available without
+      # explicit operations on the raw Mach-O data.
+      class LCStr
+        # @param lc [MachO::LoadCommands::LoadCommand] the load command
+        # @param lc_str [Fixnum, String] the offset to the beginning of the string,
+        #  or the string itself if not being initialized with a view.
+        # @raise [MachO::LCStrMalformedError] if the string is malformed
+        # @todo devise a solution such that the `lc_str` parameter is not
+        #  interpreted differently depending on `lc.view`. The current behavior
+        #  is a hack to allow viewless load command creation.
         # @api private
-        def initialize(blob)
-          @isub_image = blob >> 24
-          @itoc = blob & 0x00FFFFFF
+        def initialize(lc, lc_str)
+          view = lc.view
+
+          if view
+            lc_str_abs = view.offset + lc_str
+            lc_end = view.offset + lc.cmdsize - 1
+            raw_string = view.raw_data.slice(lc_str_abs..lc_end)
+            @string, null_byte, _padding = raw_string.partition("\x00")
+            raise LCStrMalformedError, lc if null_byte.empty?
+            @string_offset = lc_str
+          else
+            @string = lc_str
+            @string_offset = 0
+          end
+        end
+
+        # @return [String] a string representation of the LCStr
+        def to_s
+          @string
+        end
+
+        # @return [Fixnum] the offset to the beginning of the string in the load command
+        def to_i
+          @string_offset
+        end
+      end
+
+      # Represents the contextual information needed by a load command to
+      # serialize itself correctly into a binary string.
+      class SerializationContext
+        # @return [Symbol] the endianness of the serialized load command
+        attr_reader :endianness
+
+        # @return [Fixnum] the constant alignment value used to pad the serialized load command
+        attr_reader :alignment
+
+        # @param macho [MachO::MachOFile] the file to contextualize
+        # @return [MachO::LoadCommands::LoadCommand::SerializationContext] the resulting context
+        def self.context_for(macho)
+          new(macho.endianness, macho.alignment)
+        end
+
+        # @param endianness [Symbol] the endianness of the context
+        # @param alignment [Fixnum] the alignment of the context
+        # @api private
+        def initialize(endianness, alignment)
+          @endianness = endianness
+          @alignment = alignment
         end
       end
     end
-  end
 
-  # A load command containing the value of the original checksum for prebound
-  # files, or zero. Corresponds to LC_PREBIND_CKSUM.
-  class PrebindCksumCommand < LoadCommand
-    # @return [Fixnum] the checksum or 0
-    attr_reader :cksum
+    # A load command containing a single 128-bit unique random number identifying
+    # an object produced by static link editor. Corresponds to LC_UUID.
+    class UUIDCommand < LoadCommand
+      # @return [Array<Fixnum>] the UUID
+      attr_reader :uuid
 
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=3".freeze
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2a16".freeze
 
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 12
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
 
-    # @api private
-    def initialize(view, cmd, cmdsize, cksum)
-      super(view, cmd, cmdsize)
-      @cksum = cksum
-    end
-  end
+      # @api private
+      def initialize(view, cmd, cmdsize, uuid)
+        super(view, cmd, cmdsize)
+        @uuid = uuid.unpack("C16") # re-unpack for the actual UUID array
+      end
 
-  # A load command representing an rpath, which specifies a path that should
-  # be added to the current run path used to find @rpath prefixed dylibs.
-  # Corresponds to LC_RPATH.
-  class RpathCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the path to add to the run path as an LCStr
-    attr_reader :path
+      # @return [String] a string representation of the UUID
+      def uuid_string
+        hexes = uuid.map { |e| "%02x" % e }
+        segs = [
+          hexes[0..3].join, hexes[4..5].join, hexes[6..7].join,
+          hexes[8..9].join, hexes[10..15].join
+        ]
 
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=3".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 12
-
-    # @api private
-    def initialize(view, cmd, cmdsize, path)
-      super(view, cmd, cmdsize)
-      @path = LCStr.new(self, path)
+        segs.join("-")
+      end
     end
 
-    # @param context [MachO::LoadCcommand::SerializationContext] the context
-    # @return [String] the serialized fields of the load command
-    # @api private
-    def serialize(context)
-      format = Utils.specialize_format(FORMAT, context.endianness)
-      string_payload, string_offsets = Utils.pack_strings(SIZEOF, context.alignment, :path => path.to_s)
-      cmdsize = SIZEOF + string_payload.bytesize
-      [cmd, cmdsize, string_offsets[:path]].pack(format) + string_payload
-    end
-  end
+    # A load command indicating that part of this file is to be mapped into
+    # the task's address space. Corresponds to LC_SEGMENT.
+    class SegmentCommand < LoadCommand
+      # @return [String] the name of the segment
+      attr_reader :segname
 
-  # A load command representing the offsets and sizes of a blob of data in
-  # the __LINKEDIT segment. Corresponds to LC_CODE_SIGNATURE, LC_SEGMENT_SPLIT_INFO,
-  # LC_FUNCTION_STARTS, LC_DATA_IN_CODE, LC_DYLIB_CODE_SIGN_DRS, and LC_LINKER_OPTIMIZATION_HINT.
-  class LinkeditDataCommand < LoadCommand
-    # @return [Fixnum] offset to the data in the __LINKEDIT segment
-    attr_reader :dataoff
+      # @return [Fixnum] the memory address of the segment
+      attr_reader :vmaddr
 
-    # @return [Fixnum] size of the data in the __LINKEDIT segment
-    attr_reader :datasize
+      # @return [Fixnum] the memory size of the segment
+      attr_reader :vmsize
 
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=4".freeze
+      # @return [Fixnum] the file offset of the segment
+      attr_reader :fileoff
 
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 16
+      # @return [Fixnum] the amount to map from the file
+      attr_reader :filesize
 
-    # @api private
-    def initialize(view, cmd, cmdsize, dataoff, datasize)
-      super(view, cmd, cmdsize)
-      @dataoff = dataoff
-      @datasize = datasize
-    end
-  end
+      # @return [Fixnum] the maximum VM protection
+      attr_reader :maxprot
 
-  # A load command representing the offset to and size of an encrypted
-  # segment. Corresponds to LC_ENCRYPTION_INFO.
-  class EncryptionInfoCommand < LoadCommand
-    # @return [Fixnum] the offset to the encrypted segment
-    attr_reader :cryptoff
+      # @return [Fixnum] the initial VM protection
+      attr_reader :initprot
 
-    # @return [Fixnum] the size of the encrypted segment
-    attr_reader :cryptsize
+      # @return [Fixnum] the number of sections in the segment
+      attr_reader :nsects
 
-    # @return [Fixnum] the encryption system, or 0 if not encrypted yet
-    attr_reader :cryptid
+      # @return [Fixnum] any flags associated with the segment
+      attr_reader :flags
 
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=5".freeze
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2a16L=4l=2L=2".freeze
 
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 20
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 56
 
-    # @api private
-    def initialize(view, cmd, cmdsize, cryptoff, cryptsize, cryptid)
-      super(view, cmd, cmdsize)
-      @cryptoff = cryptoff
-      @cryptsize = cryptsize
-      @cryptid = cryptid
-    end
-  end
+      # @api private
+      def initialize(view, cmd, cmdsize, segname, vmaddr, vmsize, fileoff,
+                     filesize, maxprot, initprot, nsects, flags)
+        super(view, cmd, cmdsize)
+        @segname = segname.delete("\x00")
+        @vmaddr = vmaddr
+        @vmsize = vmsize
+        @fileoff = fileoff
+        @filesize = filesize
+        @maxprot = maxprot
+        @initprot = initprot
+        @nsects = nsects
+        @flags = flags
+      end
 
-  # A load command representing the offset to and size of an encrypted
-  # segment. Corresponds to LC_ENCRYPTION_INFO_64.
-  class EncryptionInfoCommand64 < LoadCommand
-    # @return [Fixnum] the offset to the encrypted segment
-    attr_reader :cryptoff
+      # All sections referenced within this segment.
+      # @return [Array<MachO::Sections::Section>] if the Mach-O is 32-bit
+      # @return [Array<MachO::Sections::Section64>] if the Mach-O is 64-bit
+      def sections
+        klass = case self
+        when SegmentCommand64
+          MachO::Sections::Section64
+        when SegmentCommand
+          MachO::Sections::Section
+        end
 
-    # @return [Fixnum] the size of the encrypted segment
-    attr_reader :cryptsize
+        bins = view.raw_data[view.offset + self.class.bytesize, nsects * klass.bytesize]
+        bins.unpack("a#{klass.bytesize}" * nsects).map do |bin|
+          klass.new_from_bin(view.endianness, bin)
+        end
+      end
 
-    # @return [Fixnum] the encryption system, or 0 if not encrypted yet
-    attr_reader :cryptid
-
-    # @return [Fixnum] 64-bit padding value
-    attr_reader :pad
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=6".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 24
-
-    # @api private
-    def initialize(view, cmd, cmdsize, cryptoff, cryptsize, cryptid, pad)
-      super(view, cmd, cmdsize)
-      @cryptoff = cryptoff
-      @cryptsize = cryptsize
-      @cryptid = cryptid
-      @pad = pad
-    end
-  end
-
-  # A load command containing the minimum OS version on which the binary
-  # was built to run. Corresponds to LC_VERSION_MIN_MACOSX and LC_VERSION_MIN_IPHONEOS.
-  class VersionMinCommand < LoadCommand
-    # @return [Fixnum] the version X.Y.Z packed as x16.y8.z8
-    attr_reader :version
-
-    # @return [Fixnum] the SDK version X.Y.Z packed as x16.y8.z8
-    attr_reader :sdk
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=4".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 16
-
-    # @api private
-    def initialize(view, cmd, cmdsize, version, sdk)
-      super(view, cmd, cmdsize)
-      @version = version
-      @sdk = sdk
+      # @example
+      #  puts "this segment relocated in/to it" if sect.flag?(:SG_NORELOC)
+      # @param flag [Symbol] a segment flag symbol
+      # @return [Boolean] true if `flag` is present in the segment's flag field
+      def flag?(flag)
+        flag = SEGMENT_FLAGS[flag]
+        return false if flag.nil?
+        flags & flag == flag
+      end
     end
 
-    # A string representation of the binary's minimum OS version.
-    # @return [String] a string representing the minimum OS version.
-    def version_string
-      binary = "%032b" % version
-      segs = [
-        binary[0..15], binary[16..23], binary[24..31]
-      ].map { |s| s.to_i(2) }
+    # A load command indicating that part of this file is to be mapped into
+    # the task's address space. Corresponds to LC_SEGMENT_64.
+    class SegmentCommand64 < SegmentCommand
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2a16Q=4l=2L=2".freeze
 
-      segs.join(".")
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 72
     end
 
-    # A string representation of the binary's SDK version.
-    # @return [String] a string representing the SDK version.
-    def sdk_string
-      binary = "%032b" % sdk
-      segs = [
-        binary[0..15], binary[16..23], binary[24..31]
-      ].map { |s| s.to_i(2) }
+    # A load command representing some aspect of shared libraries, depending
+    # on filetype. Corresponds to LC_ID_DYLIB, LC_LOAD_DYLIB, LC_LOAD_WEAK_DYLIB,
+    # and LC_REEXPORT_DYLIB.
+    class DylibCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the library's path name as an LCStr
+      attr_reader :name
 
-      segs.join(".")
-    end
-  end
+      # @return [Fixnum] the library's build time stamp
+      attr_reader :timestamp
 
-  # A load command containing the file offsets and sizes of the new
-  # compressed form of the information dyld needs to load the image.
-  # Corresponds to LC_DYLD_INFO and LC_DYLD_INFO_ONLY.
-  class DyldInfoCommand < LoadCommand
-    # @return [Fixnum] the file offset to the rebase information
-    attr_reader :rebase_off
+      # @return [Fixnum] the library's current version number
+      attr_reader :current_version
 
-    # @return [Fixnum] the size of the rebase information
-    attr_reader :rebase_size
+      # @return [Fixnum] the library's compatibility version number
+      attr_reader :compatibility_version
 
-    # @return [Fixnum] the file offset to the binding information
-    attr_reader :bind_off
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=6".freeze
 
-    # @return [Fixnum] the size of the binding information
-    attr_reader :bind_size
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
 
-    # @return [Fixnum] the file offset to the weak binding information
-    attr_reader :weak_bind_off
+      # @api private
+      def initialize(view, cmd, cmdsize, name, timestamp, current_version, compatibility_version)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+        @timestamp = timestamp
+        @current_version = current_version
+        @compatibility_version = compatibility_version
+      end
 
-    # @return [Fixnum] the size of the weak binding information
-    attr_reader :weak_bind_size
-
-    # @return [Fixnum] the file offset to the lazy binding information
-    attr_reader :lazy_bind_off
-
-    # @return [Fixnum] the size of the lazy binding information
-    attr_reader :lazy_bind_size
-
-    # @return [Fixnum] the file offset to the export information
-    attr_reader :export_off
-
-    # @return [Fixnum] the size of the export information
-    attr_reader :export_size
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=12".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 48
-
-    # @api private
-    def initialize(view, cmd, cmdsize, rebase_off, rebase_size, bind_off,
-                   bind_size, weak_bind_off, weak_bind_size, lazy_bind_off,
-                   lazy_bind_size, export_off, export_size)
-      super(view, cmd, cmdsize)
-      @rebase_off = rebase_off
-      @rebase_size = rebase_size
-      @bind_off = bind_off
-      @bind_size = bind_size
-      @weak_bind_off = weak_bind_off
-      @weak_bind_size = weak_bind_size
-      @lazy_bind_off = lazy_bind_off
-      @lazy_bind_size = lazy_bind_size
-      @export_off = export_off
-      @export_size = export_size
-    end
-  end
-
-  # A load command containing linker options embedded in object files.
-  # Corresponds to LC_LINKER_OPTION.
-  class LinkerOptionCommand < LoadCommand
-    # @return [Fixnum] the number of strings
-    attr_reader :count
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=3".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 12
-
-    # @api private
-    def initialize(view, cmd, cmdsize, count)
-      super(view, cmd, cmdsize)
-      @count = count
-    end
-  end
-
-  # A load command specifying the offset of main(). Corresponds to LC_MAIN.
-  class EntryPointCommand < LoadCommand
-    # @return [Fixnum] the file (__TEXT) offset of main()
-    attr_reader :entryoff
-
-    # @return [Fixnum] if not 0, the initial stack size.
-    attr_reader :stacksize
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=2Q=2".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 24
-
-    # @api private
-    def initialize(view, cmd, cmdsize, entryoff, stacksize)
-      super(view, cmd, cmdsize)
-      @entryoff = entryoff
-      @stacksize = stacksize
-    end
-  end
-
-  # A load command specifying the version of the sources used to build the
-  # binary. Corresponds to LC_SOURCE_VERSION.
-  class SourceVersionCommand < LoadCommand
-    # @return [Fixnum] the version packed as a24.b10.c10.d10.e10
-    attr_reader :version
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=2Q=1".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 16
-
-    # @api private
-    def initialize(view, cmd, cmdsize, version)
-      super(view, cmd, cmdsize)
-      @version = version
+      # @param context [MachO::LoadCommands::LoadCommand::SerializationContext] the context
+      # @return [String] the serialized fields of the load command
+      # @api private
+      def serialize(context)
+        format = Utils.specialize_format(FORMAT, context.endianness)
+        string_payload, string_offsets = Utils.pack_strings(SIZEOF, context.alignment, :name => name.to_s)
+        cmdsize = SIZEOF + string_payload.bytesize
+        [cmd, cmdsize, string_offsets[:name], timestamp, current_version,
+         compatibility_version].pack(format) + string_payload
+      end
     end
 
-    # A string representation of the sources used to build the binary.
-    # @return [String] a string representation of the version
-    def version_string
-      binary = "%064b" % version
-      segs = [
-        binary[0..23], binary[24..33], binary[34..43], binary[44..53],
-        binary[54..63]
-      ].map { |s| s.to_i(2) }
+    # A load command representing some aspect of the dynamic linker, depending
+    # on filetype. Corresponds to LC_ID_DYLINKER, LC_LOAD_DYLINKER, and
+    # LC_DYLD_ENVIRONMENT.
+    class DylinkerCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the dynamic linker's path name as an LCStr
+      attr_reader :name
 
-      segs.join(".")
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, name)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+      end
+
+      # @param context [MachO::LoadCommands::LoadCommand::SerializationContext] the context
+      # @return [String] the serialized fields of the load command
+      # @api private
+      def serialize(context)
+        format = Utils.specialize_format(FORMAT, context.endianness)
+        string_payload, string_offsets = Utils.pack_strings(SIZEOF, context.alignment, :name => name.to_s)
+        cmdsize = SIZEOF + string_payload.bytesize
+        [cmd, cmdsize, string_offsets[:name]].pack(format) + string_payload
+      end
     end
-  end
 
-  # An obsolete load command containing the offset and size of the (GNU style)
-  # symbol table information. Corresponds to LC_SYMSEG.
-  class SymsegCommand < LoadCommand
-    # @return [Fixnum] the offset to the symbol segment
-    attr_reader :offset
+    # A load command used to indicate dynamic libraries used in prebinding.
+    # Corresponds to LC_PREBOUND_DYLIB.
+    class PreboundDylibCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the library's path name as an LCStr
+      attr_reader :name
 
-    # @return [Fixnum] the size of the symbol segment in bytes
-    attr_reader :size
+      # @return [Fixnum] the number of modules in the library
+      attr_reader :nmodules
 
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=4".freeze
+      # @return [Fixnum] a bit vector of linked modules
+      attr_reader :linked_modules
 
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 16
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=5".freeze
 
-    # @api private
-    def initialize(view, cmd, cmdsize, offset, size)
-      super(view, cmd, cmdsize)
-      @offset = offset
-      @size = size
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 20
+
+      # @api private
+      def initialize(view, cmd, cmdsize, name, nmodules, linked_modules)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+        @nmodules = nmodules
+        @linked_modules = linked_modules
+      end
     end
-  end
 
-  # An obsolete load command containing a free format string table. Each string
-  # is null-terminated and the command is zero-padded to a multiple of 4.
-  # Corresponds to LC_IDENT.
-  class IdentCommand < LoadCommand
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=2".freeze
+    # A load command used to represent threads.
+    # @note cctools-870 has all fields of thread_command commented out except common ones (cmd, cmdsize)
+    class ThreadCommand < LoadCommand
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2".freeze
 
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 8
-  end
-
-  # An obsolete load command containing the path to a file to be loaded into
-  # memory. Corresponds to LC_FVMFILE.
-  class FvmfileCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the pathname of the file being loaded
-    attr_reader :name
-
-    # @return [Fixnum] the virtual address being loaded at
-    attr_reader :header_addr
-
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=4".freeze
-
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 16
-
-    def initialize(view, cmd, cmdsize, name, header_addr)
-      super(view, cmd, cmdsize)
-      @name = LCStr.new(self, name)
-      @header_addr = header_addr
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 8
     end
-  end
 
-  # An obsolete load command containing the path to a library to be loaded into
-  # memory. Corresponds to LC_LOADFVMLIB and LC_IDFVMLIB.
-  class FvmlibCommand < LoadCommand
-    # @return [MachO::LoadCommand::LCStr] the library's target pathname
-    attr_reader :name
+    # A load command containing the address of the dynamic shared library
+    # initialization routine and an index into the module table for the module
+    # that defines the routine. Corresponds to LC_ROUTINES.
+    class RoutinesCommand < LoadCommand
+      # @return [Fixnum] the address of the initialization routine
+      attr_reader :init_address
 
-    # @return [Fixnum] the library's minor version number
-    attr_reader :minor_version
+      # @return [Fixnum] the index into the module table that the init routine is defined in
+      attr_reader :init_module
 
-    # @return [Fixnum] the library's header address
-    attr_reader :header_addr
+      # @return [void]
+      attr_reader :reserved1
 
-    # @see MachOStructure::FORMAT
-    # @api private
-    FORMAT = "L=5".freeze
+      # @return [void]
+      attr_reader :reserved2
 
-    # @see MachOStructure::SIZEOF
-    # @api private
-    SIZEOF = 20
+      # @return [void]
+      attr_reader :reserved3
 
-    def initialize(view, cmd, cmdsize, name, minor_version, header_addr)
-      super(view, cmd, cmdsize)
-      @name = LCStr.new(self, name)
-      @minor_version = minor_version
-      @header_addr = header_addr
+      # @return [void]
+      attr_reader :reserved4
+
+      # @return [void]
+      attr_reader :reserved5
+
+      # @return [void]
+      attr_reader :reserved6
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=10".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 40
+
+      # @api private
+      def initialize(view, cmd, cmdsize, init_address, init_module, reserved1,
+                     reserved2, reserved3, reserved4, reserved5, reserved6)
+        super(view, cmd, cmdsize)
+        @init_address = init_address
+        @init_module = init_module
+        @reserved1 = reserved1
+        @reserved2 = reserved2
+        @reserved3 = reserved3
+        @reserved4 = reserved4
+        @reserved5 = reserved5
+        @reserved6 = reserved6
+      end
+    end
+
+    # A load command containing the address of the dynamic shared library
+    # initialization routine and an index into the module table for the module
+    # that defines the routine. Corresponds to LC_ROUTINES_64.
+    class RoutinesCommand64 < RoutinesCommand
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2Q=8".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 72
+    end
+
+    # A load command signifying membership of a subframework containing the name
+    # of an umbrella framework. Corresponds to LC_SUB_FRAMEWORK.
+    class SubFrameworkCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the umbrella framework name as an LCStr
+      attr_reader :umbrella
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, umbrella)
+        super(view, cmd, cmdsize)
+        @umbrella = LCStr.new(self, umbrella)
+      end
+    end
+
+    # A load command signifying membership of a subumbrella containing the name
+    # of an umbrella framework. Corresponds to LC_SUB_UMBRELLA.
+    class SubUmbrellaCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the subumbrella framework name as an LCStr
+      attr_reader :sub_umbrella
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, sub_umbrella)
+        super(view, cmd, cmdsize)
+        @sub_umbrella = LCStr.new(self, sub_umbrella)
+      end
+    end
+
+    # A load command signifying a sublibrary of a shared library. Corresponds
+    # to LC_SUB_LIBRARY.
+    class SubLibraryCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the sublibrary name as an LCStr
+      attr_reader :sub_library
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, sub_library)
+        super(view, cmd, cmdsize)
+        @sub_library = LCStr.new(self, sub_library)
+      end
+    end
+
+    # A load command signifying a shared library that is a subframework of
+    # an umbrella framework. Corresponds to LC_SUB_CLIENT.
+    class SubClientCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the subclient name as an LCStr
+      attr_reader :sub_client
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, sub_client)
+        super(view, cmd, cmdsize)
+        @sub_client = LCStr.new(self, sub_client)
+      end
+    end
+
+    # A load command containing the offsets and sizes of the link-edit 4.3BSD
+    # "stab" style symbol table information. Corresponds to LC_SYMTAB.
+    class SymtabCommand < LoadCommand
+      # @return [Fixnum] the symbol table's offset
+      attr_reader :symoff
+
+      # @return [Fixnum] the number of symbol table entries
+      attr_reader :nsyms
+
+      # @return the string table's offset
+      attr_reader :stroff
+
+      # @return the string table size in bytes
+      attr_reader :strsize
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=6".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
+
+      # @api private
+      def initialize(view, cmd, cmdsize, symoff, nsyms, stroff, strsize)
+        super(view, cmd, cmdsize)
+        @symoff = symoff
+        @nsyms = nsyms
+        @stroff = stroff
+        @strsize = strsize
+      end
+    end
+
+    # A load command containing symbolic information needed to support data
+    # structures used by the dynamic link editor. Corresponds to LC_DYSYMTAB.
+    class DysymtabCommand < LoadCommand
+      # @return [Fixnum] the index to local symbols
+      attr_reader :ilocalsym
+
+      # @return [Fixnum] the number of local symbols
+      attr_reader :nlocalsym
+
+      # @return [Fixnum] the index to externally defined symbols
+      attr_reader :iextdefsym
+
+      # @return [Fixnum] the number of externally defined symbols
+      attr_reader :nextdefsym
+
+      # @return [Fixnum] the index to undefined symbols
+      attr_reader :iundefsym
+
+      # @return [Fixnum] the number of undefined symbols
+      attr_reader :nundefsym
+
+      # @return [Fixnum] the file offset to the table of contents
+      attr_reader :tocoff
+
+      # @return [Fixnum] the number of entries in the table of contents
+      attr_reader :ntoc
+
+      # @return [Fixnum] the file offset to the module table
+      attr_reader :modtaboff
+
+      # @return [Fixnum] the number of entries in the module table
+      attr_reader :nmodtab
+
+      # @return [Fixnum] the file offset to the referenced symbol table
+      attr_reader :extrefsymoff
+
+      # @return [Fixnum] the number of entries in the referenced symbol table
+      attr_reader :nextrefsyms
+
+      # @return [Fixnum] the file offset to the indirect symbol table
+      attr_reader :indirectsymoff
+
+      # @return [Fixnum] the number of entries in the indirect symbol table
+      attr_reader :nindirectsyms
+
+      # @return [Fixnum] the file offset to the external relocation entries
+      attr_reader :extreloff
+
+      # @return [Fixnum] the number of external relocation entries
+      attr_reader :nextrel
+
+      # @return [Fixnum] the file offset to the local relocation entries
+      attr_reader :locreloff
+
+      # @return [Fixnum] the number of local relocation entries
+      attr_reader :nlocrel
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=20".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 80
+
+      # ugh
+      # @api private
+      def initialize(view, cmd, cmdsize, ilocalsym, nlocalsym, iextdefsym,
+                     nextdefsym, iundefsym, nundefsym, tocoff, ntoc, modtaboff,
+                     nmodtab, extrefsymoff, nextrefsyms, indirectsymoff,
+                     nindirectsyms, extreloff, nextrel, locreloff, nlocrel)
+        super(view, cmd, cmdsize)
+        @ilocalsym = ilocalsym
+        @nlocalsym = nlocalsym
+        @iextdefsym = iextdefsym
+        @nextdefsym = nextdefsym
+        @iundefsym = iundefsym
+        @nundefsym = nundefsym
+        @tocoff = tocoff
+        @ntoc = ntoc
+        @modtaboff = modtaboff
+        @nmodtab = nmodtab
+        @extrefsymoff = extrefsymoff
+        @nextrefsyms = nextrefsyms
+        @indirectsymoff = indirectsymoff
+        @nindirectsyms = nindirectsyms
+        @extreloff = extreloff
+        @nextrel = nextrel
+        @locreloff = locreloff
+        @nlocrel = nlocrel
+      end
+    end
+
+    # A load command containing the offset and number of hints in the two-level
+    # namespace lookup hints table. Corresponds to LC_TWOLEVEL_HINTS.
+    class TwolevelHintsCommand < LoadCommand
+      # @return [Fixnum] the offset to the hint table
+      attr_reader :htoffset
+
+      # @return [Fixnum] the number of hints in the hint table
+      attr_reader :nhints
+
+      # @return [MachO::LoadCommands::TwolevelHintsCommand::TwolevelHintTable] the hint table
+      attr_reader :table
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, htoffset, nhints)
+        super(view, cmd, cmdsize)
+        @htoffset = htoffset
+        @nhints = nhints
+        @table = TwolevelHintsTable.new(view, htoffset, nhints)
+      end
+
+      # A representation of the two-level namespace lookup hints table exposed
+      # by a {TwolevelHintsCommand} (`LC_TWOLEVEL_HINTS`).
+      class TwolevelHintsTable
+        # @return [Array<MachO::LoadCommands::TwoLevelHintsCommand::TwoLevelHintsTable::TwoLevelHint>] all hints in the table
+        attr_reader :hints
+
+        # @param view [MachO::MachOView] the view into the current Mach-O
+        # @param htoffset [Fixnum] the offset of the hints table
+        # @param nhints [Fixnum] the number of two-level hints in the table
+        # @api private
+        def initialize(view, htoffset, nhints)
+          format = Utils.specialize_format("L=#{nhints}", view.endianness)
+          raw_table = view.raw_data[htoffset, nhints * 4]
+          blobs = raw_table.unpack(format)
+
+          @hints = blobs.map { |b| TwolevelHint.new(b) }
+        end
+
+        # An individual two-level namespace lookup hint.
+        class TwolevelHint
+          # @return [Fixnum] the index into the sub-images
+          attr_reader :isub_image
+
+          # @return [Fixnum] the index into the table of contents
+          attr_reader :itoc
+
+          # @param blob [Fixnum] the 32-bit number containing the lookup hint
+          # @api private
+          def initialize(blob)
+            @isub_image = blob >> 24
+            @itoc = blob & 0x00FFFFFF
+          end
+        end
+      end
+    end
+
+    # A load command containing the value of the original checksum for prebound
+    # files, or zero. Corresponds to LC_PREBIND_CKSUM.
+    class PrebindCksumCommand < LoadCommand
+      # @return [Fixnum] the checksum or 0
+      attr_reader :cksum
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, cksum)
+        super(view, cmd, cmdsize)
+        @cksum = cksum
+      end
+    end
+
+    # A load command representing an rpath, which specifies a path that should
+    # be added to the current run path used to find @rpath prefixed dylibs.
+    # Corresponds to LC_RPATH.
+    class RpathCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the path to add to the run path as an LCStr
+      attr_reader :path
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, path)
+        super(view, cmd, cmdsize)
+        @path = LCStr.new(self, path)
+      end
+
+      # @param context [MachO::LoadCommands::LoadCommand::SerializationContext] the context
+      # @return [String] the serialized fields of the load command
+      # @api private
+      def serialize(context)
+        format = Utils.specialize_format(FORMAT, context.endianness)
+        string_payload, string_offsets = Utils.pack_strings(SIZEOF, context.alignment, :path => path.to_s)
+        cmdsize = SIZEOF + string_payload.bytesize
+        [cmd, cmdsize, string_offsets[:path]].pack(format) + string_payload
+      end
+    end
+
+    # A load command representing the offsets and sizes of a blob of data in
+    # the __LINKEDIT segment. Corresponds to LC_CODE_SIGNATURE, LC_SEGMENT_SPLIT_INFO,
+    # LC_FUNCTION_STARTS, LC_DATA_IN_CODE, LC_DYLIB_CODE_SIGN_DRS, and LC_LINKER_OPTIMIZATION_HINT.
+    class LinkeditDataCommand < LoadCommand
+      # @return [Fixnum] offset to the data in the __LINKEDIT segment
+      attr_reader :dataoff
+
+      # @return [Fixnum] size of the data in the __LINKEDIT segment
+      attr_reader :datasize
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, dataoff, datasize)
+        super(view, cmd, cmdsize)
+        @dataoff = dataoff
+        @datasize = datasize
+      end
+    end
+
+    # A load command representing the offset to and size of an encrypted
+    # segment. Corresponds to LC_ENCRYPTION_INFO.
+    class EncryptionInfoCommand < LoadCommand
+      # @return [Fixnum] the offset to the encrypted segment
+      attr_reader :cryptoff
+
+      # @return [Fixnum] the size of the encrypted segment
+      attr_reader :cryptsize
+
+      # @return [Fixnum] the encryption system, or 0 if not encrypted yet
+      attr_reader :cryptid
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=5".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 20
+
+      # @api private
+      def initialize(view, cmd, cmdsize, cryptoff, cryptsize, cryptid)
+        super(view, cmd, cmdsize)
+        @cryptoff = cryptoff
+        @cryptsize = cryptsize
+        @cryptid = cryptid
+      end
+    end
+
+    # A load command representing the offset to and size of an encrypted
+    # segment. Corresponds to LC_ENCRYPTION_INFO_64.
+    class EncryptionInfoCommand64 < LoadCommand
+      # @return [Fixnum] the offset to the encrypted segment
+      attr_reader :cryptoff
+
+      # @return [Fixnum] the size of the encrypted segment
+      attr_reader :cryptsize
+
+      # @return [Fixnum] the encryption system, or 0 if not encrypted yet
+      attr_reader :cryptid
+
+      # @return [Fixnum] 64-bit padding value
+      attr_reader :pad
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=6".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
+
+      # @api private
+      def initialize(view, cmd, cmdsize, cryptoff, cryptsize, cryptid, pad)
+        super(view, cmd, cmdsize)
+        @cryptoff = cryptoff
+        @cryptsize = cryptsize
+        @cryptid = cryptid
+        @pad = pad
+      end
+    end
+
+    # A load command containing the minimum OS version on which the binary
+    # was built to run. Corresponds to LC_VERSION_MIN_MACOSX and LC_VERSION_MIN_IPHONEOS.
+    class VersionMinCommand < LoadCommand
+      # @return [Fixnum] the version X.Y.Z packed as x16.y8.z8
+      attr_reader :version
+
+      # @return [Fixnum] the SDK version X.Y.Z packed as x16.y8.z8
+      attr_reader :sdk
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, version, sdk)
+        super(view, cmd, cmdsize)
+        @version = version
+        @sdk = sdk
+      end
+
+      # A string representation of the binary's minimum OS version.
+      # @return [String] a string representing the minimum OS version.
+      def version_string
+        binary = "%032b" % version
+        segs = [
+          binary[0..15], binary[16..23], binary[24..31]
+        ].map { |s| s.to_i(2) }
+
+        segs.join(".")
+      end
+
+      # A string representation of the binary's SDK version.
+      # @return [String] a string representing the SDK version.
+      def sdk_string
+        binary = "%032b" % sdk
+        segs = [
+          binary[0..15], binary[16..23], binary[24..31]
+        ].map { |s| s.to_i(2) }
+
+        segs.join(".")
+      end
+    end
+
+    # A load command containing the file offsets and sizes of the new
+    # compressed form of the information dyld needs to load the image.
+    # Corresponds to LC_DYLD_INFO and LC_DYLD_INFO_ONLY.
+    class DyldInfoCommand < LoadCommand
+      # @return [Fixnum] the file offset to the rebase information
+      attr_reader :rebase_off
+
+      # @return [Fixnum] the size of the rebase information
+      attr_reader :rebase_size
+
+      # @return [Fixnum] the file offset to the binding information
+      attr_reader :bind_off
+
+      # @return [Fixnum] the size of the binding information
+      attr_reader :bind_size
+
+      # @return [Fixnum] the file offset to the weak binding information
+      attr_reader :weak_bind_off
+
+      # @return [Fixnum] the size of the weak binding information
+      attr_reader :weak_bind_size
+
+      # @return [Fixnum] the file offset to the lazy binding information
+      attr_reader :lazy_bind_off
+
+      # @return [Fixnum] the size of the lazy binding information
+      attr_reader :lazy_bind_size
+
+      # @return [Fixnum] the file offset to the export information
+      attr_reader :export_off
+
+      # @return [Fixnum] the size of the export information
+      attr_reader :export_size
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=12".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 48
+
+      # @api private
+      def initialize(view, cmd, cmdsize, rebase_off, rebase_size, bind_off,
+                     bind_size, weak_bind_off, weak_bind_size, lazy_bind_off,
+                     lazy_bind_size, export_off, export_size)
+        super(view, cmd, cmdsize)
+        @rebase_off = rebase_off
+        @rebase_size = rebase_size
+        @bind_off = bind_off
+        @bind_size = bind_size
+        @weak_bind_off = weak_bind_off
+        @weak_bind_size = weak_bind_size
+        @lazy_bind_off = lazy_bind_off
+        @lazy_bind_size = lazy_bind_size
+        @export_off = export_off
+        @export_size = export_size
+      end
+    end
+
+    # A load command containing linker options embedded in object files.
+    # Corresponds to LC_LINKER_OPTION.
+    class LinkerOptionCommand < LoadCommand
+      # @return [Fixnum] the number of strings
+      attr_reader :count
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, count)
+        super(view, cmd, cmdsize)
+        @count = count
+      end
+    end
+
+    # A load command specifying the offset of main(). Corresponds to LC_MAIN.
+    class EntryPointCommand < LoadCommand
+      # @return [Fixnum] the file (__TEXT) offset of main()
+      attr_reader :entryoff
+
+      # @return [Fixnum] if not 0, the initial stack size.
+      attr_reader :stacksize
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2Q=2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
+
+      # @api private
+      def initialize(view, cmd, cmdsize, entryoff, stacksize)
+        super(view, cmd, cmdsize)
+        @entryoff = entryoff
+        @stacksize = stacksize
+      end
+    end
+
+    # A load command specifying the version of the sources used to build the
+    # binary. Corresponds to LC_SOURCE_VERSION.
+    class SourceVersionCommand < LoadCommand
+      # @return [Fixnum] the version packed as a24.b10.c10.d10.e10
+      attr_reader :version
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2Q=1".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, version)
+        super(view, cmd, cmdsize)
+        @version = version
+      end
+
+      # A string representation of the sources used to build the binary.
+      # @return [String] a string representation of the version
+      def version_string
+        binary = "%064b" % version
+        segs = [
+          binary[0..23], binary[24..33], binary[34..43], binary[44..53],
+          binary[54..63]
+        ].map { |s| s.to_i(2) }
+
+        segs.join(".")
+      end
+    end
+
+    # An obsolete load command containing the offset and size of the (GNU style)
+    # symbol table information. Corresponds to LC_SYMSEG.
+    class SymsegCommand < LoadCommand
+      # @return [Fixnum] the offset to the symbol segment
+      attr_reader :offset
+
+      # @return [Fixnum] the size of the symbol segment in bytes
+      attr_reader :size
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, offset, size)
+        super(view, cmd, cmdsize)
+        @offset = offset
+        @size = size
+      end
+    end
+
+    # An obsolete load command containing a free format string table. Each string
+    # is null-terminated and the command is zero-padded to a multiple of 4.
+    # Corresponds to LC_IDENT.
+    class IdentCommand < LoadCommand
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 8
+    end
+
+    # An obsolete load command containing the path to a file to be loaded into
+    # memory. Corresponds to LC_FVMFILE.
+    class FvmfileCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the pathname of the file being loaded
+      attr_reader :name
+
+      # @return [Fixnum] the virtual address being loaded at
+      attr_reader :header_addr
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      def initialize(view, cmd, cmdsize, name, header_addr)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+        @header_addr = header_addr
+      end
+    end
+
+    # An obsolete load command containing the path to a library to be loaded into
+    # memory. Corresponds to LC_LOADFVMLIB and LC_IDFVMLIB.
+    class FvmlibCommand < LoadCommand
+      # @return [MachO::LoadCommands::LoadCommand::LCStr] the library's target pathname
+      attr_reader :name
+
+      # @return [Fixnum] the library's minor version number
+      attr_reader :minor_version
+
+      # @return [Fixnum] the library's header address
+      attr_reader :header_addr
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=5".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 20
+
+      def initialize(view, cmd, cmdsize, name, minor_version, header_addr)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+        @minor_version = minor_version
+        @header_addr = header_addr
+      end
     end
   end
 end

--- a/lib/macho/sections.rb
+++ b/lib/macho/sections.rb
@@ -1,170 +1,173 @@
 module MachO
-  # type mask
-  SECTION_TYPE = 0x000000ff
+  # Classes and constants for parsing sections in Mach-O binaries.
+  module Sections
+    # type mask
+    SECTION_TYPE = 0x000000ff
 
-  # attributes mask
-  SECTION_ATTRIBUTES = 0xffffff00
+    # attributes mask
+    SECTION_ATTRIBUTES = 0xffffff00
 
-  # user settable attributes mask
-  SECTION_ATTRIBUTES_USR = 0xff000000
+    # user settable attributes mask
+    SECTION_ATTRIBUTES_USR = 0xff000000
 
-  # system settable attributes mask
-  SECTION_ATTRIBUTES_SYS = 0x00ffff00
+    # system settable attributes mask
+    SECTION_ATTRIBUTES_SYS = 0x00ffff00
 
-  # association of section flag symbols to values
-  # @api private
-  SECTION_FLAGS = {
-    :S_REGULAR => 0x0,
-    :S_ZEROFILL => 0x1,
-    :S_CSTRING_LITERALS => 0x2,
-    :S_4BYTE_LITERALS => 0x3,
-    :S_8BYTE_LITERALS => 0x4,
-    :S_LITERAL_POINTERS => 0x5,
-    :S_NON_LAZY_SYMBOL_POINTERS => 0x6,
-    :S_LAZY_SYMBOL_POINTERS => 0x7,
-    :S_SYMBOL_STUBS => 0x8,
-    :S_MOD_INIT_FUNC_POINTERS => 0x9,
-    :S_MOD_TERM_FUNC_POINTERS => 0xa,
-    :S_COALESCED => 0xb,
-    :S_GB_ZEROFILE => 0xc,
-    :S_INTERPOSING => 0xd,
-    :S_16BYTE_LITERALS => 0xe,
-    :S_DTRACE_DOF => 0xf,
-    :S_LAZY_DYLIB_SYMBOL_POINTERS => 0x10,
-    :S_THREAD_LOCAL_REGULAR => 0x11,
-    :S_THREAD_LOCAL_ZEROFILL => 0x12,
-    :S_THREAD_LOCAL_VARIABLES => 0x13,
-    :S_THREAD_LOCAL_VARIABLE_POINTERS => 0x14,
-    :S_THREAD_LOCAL_INIT_FUNCTION_POINTERS => 0x15,
-    :S_ATTR_PURE_INSTRUCTIONS => 0x80000000,
-    :S_ATTR_NO_TOC => 0x40000000,
-    :S_ATTR_STRIP_STATIC_SYMS => 0x20000000,
-    :S_ATTR_NO_DEAD_STRIP => 0x10000000,
-    :S_ATTR_LIVE_SUPPORT => 0x08000000,
-    :S_ATTR_SELF_MODIFYING_CODE => 0x04000000,
-    :S_ATTR_DEBUG => 0x02000000,
-    :S_ATTR_SOME_INSTRUCTIONS => 0x00000400,
-    :S_ATTR_EXT_RELOC => 0x00000200,
-    :S_ATTR_LOC_RELOC => 0x00000100,
-  }.freeze
-
-  # association of section name symbols to names
-  # @api private
-  SECTION_NAMES = {
-    :SECT_TEXT => "__text",
-    :SECT_FVMLIB_INIT0 => "__fvmlib_init0",
-    :SECT_FVMLIB_INIT1 => "__fvmlib_init1",
-    :SECT_DATA => "__data",
-    :SECT_BSS => "__bss",
-    :SECT_COMMON => "__common",
-    :SECT_OBJC_SYMBOLS => "__symbol_table",
-    :SECT_OBJC_MODULES => "__module_info",
-    :SECT_OBJC_STRINGS => "__selector_strs",
-    :SECT_OBJC_REFS => "__selector_refs",
-    :SECT_ICON_HEADER => "__header",
-    :SECT_ICON_TIFF => "__tiff",
-  }.freeze
-
-  # Represents a section of a segment for 32-bit architectures.
-  class Section < MachOStructure
-    # @return [String] the name of the section, including null pad bytes
-    attr_reader :sectname
-
-    # @return [String] the name of the segment's section, including null pad bytes
-    attr_reader :segname
-
-    # @return [Fixnum] the memory address of the section
-    attr_reader :addr
-
-    # @return [Fixnum] the size, in bytes, of the section
-    attr_reader :size
-
-    # @return [Fixnum] the file offset of the section
-    attr_reader :offset
-
-    # @return [Fixnum] the section alignment (power of 2) of the section
-    attr_reader :align
-
-    # @return [Fixnum] the file offset of the section's relocation entries
-    attr_reader :reloff
-
-    # @return [Fixnum] the number of relocation entries
-    attr_reader :nreloc
-
-    # @return [Fixnum] flags for type and attributes of the section
-    attr_reader :flags
-
-    # @return [void] reserved (for offset or index)
-    attr_reader :reserved1
-
-    # @return [void] reserved (for count or sizeof)
-    attr_reader :reserved2
-
-    # @see MachOStructure::FORMAT
-    FORMAT = "a16a16L=9".freeze
-
-    # @see MachOStructure::SIZEOF
-    SIZEOF = 68
-
+    # association of section flag symbols to values
     # @api private
-    def initialize(sectname, segname, addr, size, offset, align, reloff,
-                   nreloc, flags, reserved1, reserved2)
-      @sectname = sectname
-      @segname = segname
-      @addr = addr
-      @size = size
-      @offset = offset
-      @align = align
-      @reloff = reloff
-      @nreloc = nreloc
-      @flags = flags
-      @reserved1 = reserved1
-      @reserved2 = reserved2
-    end
+    SECTION_FLAGS = {
+      :S_REGULAR => 0x0,
+      :S_ZEROFILL => 0x1,
+      :S_CSTRING_LITERALS => 0x2,
+      :S_4BYTE_LITERALS => 0x3,
+      :S_8BYTE_LITERALS => 0x4,
+      :S_LITERAL_POINTERS => 0x5,
+      :S_NON_LAZY_SYMBOL_POINTERS => 0x6,
+      :S_LAZY_SYMBOL_POINTERS => 0x7,
+      :S_SYMBOL_STUBS => 0x8,
+      :S_MOD_INIT_FUNC_POINTERS => 0x9,
+      :S_MOD_TERM_FUNC_POINTERS => 0xa,
+      :S_COALESCED => 0xb,
+      :S_GB_ZEROFILE => 0xc,
+      :S_INTERPOSING => 0xd,
+      :S_16BYTE_LITERALS => 0xe,
+      :S_DTRACE_DOF => 0xf,
+      :S_LAZY_DYLIB_SYMBOL_POINTERS => 0x10,
+      :S_THREAD_LOCAL_REGULAR => 0x11,
+      :S_THREAD_LOCAL_ZEROFILL => 0x12,
+      :S_THREAD_LOCAL_VARIABLES => 0x13,
+      :S_THREAD_LOCAL_VARIABLE_POINTERS => 0x14,
+      :S_THREAD_LOCAL_INIT_FUNCTION_POINTERS => 0x15,
+      :S_ATTR_PURE_INSTRUCTIONS => 0x80000000,
+      :S_ATTR_NO_TOC => 0x40000000,
+      :S_ATTR_STRIP_STATIC_SYMS => 0x20000000,
+      :S_ATTR_NO_DEAD_STRIP => 0x10000000,
+      :S_ATTR_LIVE_SUPPORT => 0x08000000,
+      :S_ATTR_SELF_MODIFYING_CODE => 0x04000000,
+      :S_ATTR_DEBUG => 0x02000000,
+      :S_ATTR_SOME_INSTRUCTIONS => 0x00000400,
+      :S_ATTR_EXT_RELOC => 0x00000200,
+      :S_ATTR_LOC_RELOC => 0x00000100,
+    }.freeze
 
-    # @return [String] the section's name, with any trailing NULL characters removed
-    def section_name
-      sectname.delete("\x00")
-    end
-
-    # @return [String] the parent segment's name, with any trailing NULL characters removed
-    def segment_name
-      segname.delete("\x00")
-    end
-
-    # @return [Boolean] true if the section has no contents (i.e, `size` is 0)
-    def empty?
-      size.zero?
-    end
-
-    # @example
-    #  puts "this section is regular" if sect.flag?(:S_REGULAR)
-    # @param flag [Symbol] a section flag symbol
-    # @return [Boolean] true if `flag` is present in the section's flag field
-    def flag?(flag)
-      flag = SECTION_FLAGS[flag]
-      return false if flag.nil?
-      flags & flag == flag
-    end
-  end
-
-  # Represents a section of a segment for 64-bit architectures.
-  class Section64 < Section
-    # @return [void] reserved
-    attr_reader :reserved3
-
-    # @see MachOStructure::FORMAT
-    FORMAT = "a16a16Q=2L=8".freeze
-
-    # @see MachOStructure::SIZEOF
-    SIZEOF = 80
-
+    # association of section name symbols to names
     # @api private
-    def initialize(sectname, segname, addr, size, offset, align, reloff,
-                   nreloc, flags, reserved1, reserved2, reserved3)
-      super(sectname, segname, addr, size, offset, align, reloff,
-        nreloc, flags, reserved1, reserved2)
-      @reserved3 = reserved3
+    SECTION_NAMES = {
+      :SECT_TEXT => "__text",
+      :SECT_FVMLIB_INIT0 => "__fvmlib_init0",
+      :SECT_FVMLIB_INIT1 => "__fvmlib_init1",
+      :SECT_DATA => "__data",
+      :SECT_BSS => "__bss",
+      :SECT_COMMON => "__common",
+      :SECT_OBJC_SYMBOLS => "__symbol_table",
+      :SECT_OBJC_MODULES => "__module_info",
+      :SECT_OBJC_STRINGS => "__selector_strs",
+      :SECT_OBJC_REFS => "__selector_refs",
+      :SECT_ICON_HEADER => "__header",
+      :SECT_ICON_TIFF => "__tiff",
+    }.freeze
+
+    # Represents a section of a segment for 32-bit architectures.
+    class Section < MachOStructure
+      # @return [String] the name of the section, including null pad bytes
+      attr_reader :sectname
+
+      # @return [String] the name of the segment's section, including null pad bytes
+      attr_reader :segname
+
+      # @return [Fixnum] the memory address of the section
+      attr_reader :addr
+
+      # @return [Fixnum] the size, in bytes, of the section
+      attr_reader :size
+
+      # @return [Fixnum] the file offset of the section
+      attr_reader :offset
+
+      # @return [Fixnum] the section alignment (power of 2) of the section
+      attr_reader :align
+
+      # @return [Fixnum] the file offset of the section's relocation entries
+      attr_reader :reloff
+
+      # @return [Fixnum] the number of relocation entries
+      attr_reader :nreloc
+
+      # @return [Fixnum] flags for type and attributes of the section
+      attr_reader :flags
+
+      # @return [void] reserved (for offset or index)
+      attr_reader :reserved1
+
+      # @return [void] reserved (for count or sizeof)
+      attr_reader :reserved2
+
+      # @see MachOStructure::FORMAT
+      FORMAT = "a16a16L=9".freeze
+
+      # @see MachOStructure::SIZEOF
+      SIZEOF = 68
+
+      # @api private
+      def initialize(sectname, segname, addr, size, offset, align, reloff,
+                     nreloc, flags, reserved1, reserved2)
+        @sectname = sectname
+        @segname = segname
+        @addr = addr
+        @size = size
+        @offset = offset
+        @align = align
+        @reloff = reloff
+        @nreloc = nreloc
+        @flags = flags
+        @reserved1 = reserved1
+        @reserved2 = reserved2
+      end
+
+      # @return [String] the section's name, with any trailing NULL characters removed
+      def section_name
+        sectname.delete("\x00")
+      end
+
+      # @return [String] the parent segment's name, with any trailing NULL characters removed
+      def segment_name
+        segname.delete("\x00")
+      end
+
+      # @return [Boolean] true if the section has no contents (i.e, `size` is 0)
+      def empty?
+        size.zero?
+      end
+
+      # @example
+      #  puts "this section is regular" if sect.flag?(:S_REGULAR)
+      # @param flag [Symbol] a section flag symbol
+      # @return [Boolean] true if `flag` is present in the section's flag field
+      def flag?(flag)
+        flag = SECTION_FLAGS[flag]
+        return false if flag.nil?
+        flags & flag == flag
+      end
+    end
+
+    # Represents a section of a segment for 64-bit architectures.
+    class Section64 < Section
+      # @return [void] reserved
+      attr_reader :reserved3
+
+      # @see MachOStructure::FORMAT
+      FORMAT = "a16a16Q=2L=8".freeze
+
+      # @see MachOStructure::SIZEOF
+      SIZEOF = 80
+
+      # @api private
+      def initialize(sectname, segname, addr, size, offset, align, reloff,
+                     nreloc, flags, reserved1, reserved2, reserved3)
+        super(sectname, segname, addr, size, offset, align, reloff,
+          nreloc, flags, reserved1, reserved2)
+        @reserved3 = reserved3
+      end
     end
   end
 end

--- a/lib/macho/utils.rb
+++ b/lib/macho/utils.rb
@@ -55,42 +55,42 @@ module MachO
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid Mach-O magic number, false otherwise
     def self.magic?(num)
-      MH_MAGICS.key?(num)
+      Headers::MH_MAGICS.key?(num)
     end
 
     # Compares the given number to valid Fat magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid Fat magic number, false otherwise
     def self.fat_magic?(num)
-      num == FAT_MAGIC
+      num == Headers::FAT_MAGIC
     end
 
     # Compares the given number to valid 32-bit Mach-O magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid 32-bit magic number, false otherwise
     def self.magic32?(num)
-      num == MH_MAGIC || num == MH_CIGAM
+      num == Headers::MH_MAGIC || num == Headers::MH_CIGAM
     end
 
     # Compares the given number to valid 64-bit Mach-O magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid 64-bit magic number, false otherwise
     def self.magic64?(num)
-      num == MH_MAGIC_64 || num == MH_CIGAM_64
+      num == Headers::MH_MAGIC_64 || num == Headers::MH_CIGAM_64
     end
 
     # Compares the given number to valid little-endian magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid little-endian magic number, false otherwise
     def self.little_magic?(num)
-      num == MH_CIGAM || num == MH_CIGAM_64
+      num == Headers::MH_CIGAM || num == Headers::MH_CIGAM_64
     end
 
     # Compares the given number to valid big-endian magic numbers.
     # @param num [Fixnum] the number being checked
     # @return [Boolean] true if `num` is a valid big-endian magic number, false otherwise
     def self.big_magic?(num)
-      num == MH_CIGAM || num == MH_CIGAM_64
+      num == Headers::MH_CIGAM || num == Headers::MH_CIGAM_64
     end
   end
 end

--- a/test/test_create_load_commands.rb
+++ b/test/test_create_load_commands.rb
@@ -7,26 +7,26 @@ class MachOLoadCommandCreationTest < Minitest::Test
 
   def test_create_uncreatable_command
     assert_raises MachO::LoadCommandNotCreatableError do
-      MachO::LoadCommand.create(:LC_SEGMENT, 4)
+      MachO::LoadCommands::LoadCommand.create(:LC_SEGMENT, 4)
     end
   end
 
   def test_create_wrong_command_arity
     assert_raises MachO::LoadCommandCreationArityError do
-      MachO::LoadCommand.create(:LC_ID_DYLIB, 4, "missing arguments")
+      MachO::LoadCommands::LoadCommand.create(:LC_ID_DYLIB, 4, "missing arguments")
     end
   end
 
   def test_create_dylib_commands
     # all dylib commands are creatable, so test them all
-    dylib_commands = MachO::DYLIB_LOAD_COMMANDS + [:LC_ID_DYLIB]
+    dylib_commands = MachO::LoadCommands::DYLIB_LOAD_COMMANDS + [:LC_ID_DYLIB]
     dylib_commands.each do |cmd_sym|
-      lc = MachO::LoadCommand.create(cmd_sym, "test", 0, 0, 0)
+      lc = MachO::LoadCommands::LoadCommand.create(cmd_sym, "test", 0, 0, 0)
 
       assert lc
-      assert_kind_of MachO::DylibCommand, lc
+      assert_kind_of MachO::LoadCommands::DylibCommand, lc
       assert lc.name
-      assert_kind_of MachO::LoadCommand::LCStr, lc.name
+      assert_kind_of MachO::LoadCommands::LoadCommand::LCStr, lc.name
       assert_equal "test", lc.name.to_s
       assert_equal 0, lc.timestamp
       assert_equal 0, lc.current_version
@@ -35,12 +35,12 @@ class MachOLoadCommandCreationTest < Minitest::Test
   end
 
   def test_create_rpath_command
-    lc = MachO::LoadCommand.create(:LC_RPATH, "test")
+    lc = MachO::LoadCommands::LoadCommand.create(:LC_RPATH, "test")
 
     assert lc
-    assert_kind_of MachO::RpathCommand, lc
+    assert_kind_of MachO::LoadCommands::RpathCommand, lc
     assert lc.path
-    assert_kind_of MachO::LoadCommand::LCStr, lc.path
+    assert_kind_of MachO::LoadCommands::LoadCommand::LCStr, lc.path
     assert_equal "test", lc.path.to_s
   end
 end

--- a/test/test_fat.rb
+++ b/test/test_fat.rb
@@ -45,7 +45,7 @@ class FatFileTest < Minitest::Test
       header = file.header
 
       assert header
-      assert_kind_of MachO::FatHeader, header
+      assert_kind_of MachO::Headers::FatHeader, header
       assert_kind_of Fixnum, header.magic
       assert_kind_of Fixnum, header.nfat_arch
     end
@@ -63,7 +63,7 @@ class FatFileTest < Minitest::Test
 
       archs.each do |arch|
         assert arch
-        assert_kind_of MachO::FatArch, arch
+        assert_kind_of MachO::Headers::FatArch, arch
         assert_kind_of Fixnum, arch.cputype
         assert_kind_of Fixnum, arch.cpusubtype
         assert_kind_of Fixnum, arch.offset
@@ -176,12 +176,12 @@ class FatFileTest < Minitest::Test
           # the ones that don't exist
           # https://github.com/Homebrew/ruby-macho/pull/24#issuecomment-226287121
           if lc
-            assert_kind_of MachO::DylibCommand, lc
+            assert_kind_of MachO::LoadCommands::DylibCommand, lc
 
             dylib_name = lc.name
 
             assert dylib_name
-            assert_kind_of MachO::LoadCommand::LCStr, dylib_name
+            assert_kind_of MachO::LoadCommands::LoadCommand::LCStr, dylib_name
           end
         end
       end
@@ -483,7 +483,7 @@ class FatFileTest < Minitest::Test
       assert_instance_of Array, file.dylib_load_commands
 
       file.dylib_load_commands.each do |lc|
-        assert_kind_of MachO::DylibCommand, lc
+        assert_kind_of MachO::LoadCommands::DylibCommand, lc
       end
     end
   end

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -35,7 +35,7 @@ class MachOFileTest < Minitest::Test
 
       file.load_commands.each do |lc|
         assert lc
-        assert_kind_of MachO::LoadCommand, lc
+        assert_kind_of MachO::LoadCommands::LoadCommand, lc
         assert_kind_of Fixnum, lc.offset
         assert_kind_of Fixnum, lc.cmd
         assert_kind_of Fixnum, lc.cmdsize
@@ -65,8 +65,8 @@ class MachOFileTest < Minitest::Test
       header = file.header
 
       assert header
-      assert_kind_of MachO::MachHeader, header if file.magic32?
-      assert_kind_of MachO::MachHeader64, header if file.magic64?
+      assert_kind_of MachO::Headers::MachHeader, header if file.magic32?
+      assert_kind_of MachO::Headers::MachHeader64, header if file.magic64?
       assert_kind_of Fixnum, header.magic
       assert_kind_of Fixnum, header.cputype
       assert_kind_of Fixnum, header.cpusubtype
@@ -90,8 +90,8 @@ class MachOFileTest < Minitest::Test
 
       segments.each do |seg|
         assert seg
-        assert_kind_of MachO::SegmentCommand, seg if file.magic32?
-        assert_kind_of MachO::SegmentCommand64, seg if file.magic64?
+        assert_kind_of MachO::LoadCommands::SegmentCommand, seg if file.magic32?
+        assert_kind_of MachO::LoadCommands::SegmentCommand64, seg if file.magic64?
         assert_kind_of String, seg.segname
         assert_kind_of Fixnum, seg.vmaddr
         assert_kind_of Fixnum, seg.vmsize
@@ -109,8 +109,8 @@ class MachOFileTest < Minitest::Test
 
         sections.each do |sect|
           assert sect
-          assert_kind_of MachO::Section, sect if seg.is_a? MachO::SegmentCommand
-          assert_kind_of MachO::Section64, sect if seg.is_a? MachO::SegmentCommand64
+          assert_kind_of MachO::Sections::Section, sect if seg.is_a? MachO::LoadCommands::SegmentCommand
+          assert_kind_of MachO::Sections::Section64, sect if seg.is_a? MachO::LoadCommands::SegmentCommand64
           assert_kind_of String, sect.sectname
           assert_kind_of String, sect.segname
           assert_kind_of Fixnum, sect.addr
@@ -123,7 +123,7 @@ class MachOFileTest < Minitest::Test
           refute sect.flag?(:THIS_IS_A_MADE_UP_FLAG)
           assert_kind_of Fixnum, sect.reserved1
           assert_kind_of Fixnum, sect.reserved2
-          assert_kind_of Fixnum, sect.reserved3 if sect.is_a? MachO::Section64
+          assert_kind_of Fixnum, sect.reserved3 if sect.is_a? MachO::Sections::Section64
         end
       end
     end
@@ -228,12 +228,12 @@ class MachOFileTest < Minitest::Test
         # the ones that don't exist
         # https://github.com/Homebrew/ruby-macho/pull/24#issuecomment-226287121
         if lc
-          assert_kind_of MachO::DylibCommand, lc
+          assert_kind_of MachO::LoadCommands::DylibCommand, lc
 
           dylib_name = lc.name
 
           assert dylib_name
-          assert_kind_of MachO::LoadCommand::LCStr, dylib_name
+          assert_kind_of MachO::LoadCommands::LoadCommand::LCStr, dylib_name
         end
       end
     end

--- a/test/test_serialize_load_commands.rb
+++ b/test/test_serialize_load_commands.rb
@@ -13,7 +13,7 @@ class MachOLoadCommandSerializationTest < Minitest::Test
     refute lc.serializable?
 
     assert_raises MachO::LoadCommandNotSerializableError do
-      lc.serialize(MachO::LoadCommand::SerializationContext.context_for(file))
+      lc.serialize(MachO::LoadCommands::LoadCommand::SerializationContext.context_for(file))
     end
   end
 
@@ -62,9 +62,9 @@ class MachOLoadCommandSerializationTest < Minitest::Test
 
     filenames.each do |filename|
       file = MachO::MachOFile.new(filename)
-      ctx = MachO::LoadCommand::SerializationContext.context_for(file)
+      ctx = MachO::LoadCommands::LoadCommand::SerializationContext.context_for(file)
       lc = file[:LC_LOAD_DYLIB].first
-      lc2 = MachO::LoadCommand.create(:LC_LOAD_DYLIB, lc.name.to_s,
+      lc2 = MachO::LoadCommands::LoadCommand.create(:LC_LOAD_DYLIB, lc.name.to_s,
         lc.timestamp, lc.current_version, lc.compatibility_version)
       blob = lc.view.raw_data[lc.view.offset, lc.cmdsize]
 
@@ -78,9 +78,9 @@ class MachOLoadCommandSerializationTest < Minitest::Test
 
     filenames.each do |filename|
       file = MachO::MachOFile.new(filename)
-      ctx = MachO::LoadCommand::SerializationContext.context_for(file)
+      ctx = MachO::LoadCommands::LoadCommand::SerializationContext.context_for(file)
       lc = file[:LC_ID_DYLIB].first
-      lc2 = MachO::LoadCommand.create(:LC_ID_DYLIB, lc.name.to_s,
+      lc2 = MachO::LoadCommands::LoadCommand.create(:LC_ID_DYLIB, lc.name.to_s,
         lc.timestamp, lc.current_version, lc.compatibility_version)
       blob = lc.view.raw_data[lc.view.offset, lc.cmdsize]
 
@@ -94,9 +94,9 @@ class MachOLoadCommandSerializationTest < Minitest::Test
 
     filenames.each do |filename|
       file = MachO::MachOFile.new(filename)
-      ctx = MachO::LoadCommand::SerializationContext.context_for(file)
+      ctx = MachO::LoadCommands::LoadCommand::SerializationContext.context_for(file)
       lc = file[:LC_LOAD_DYLINKER].first
-      lc2 = MachO::LoadCommand.create(:LC_LOAD_DYLINKER, lc.name.to_s)
+      lc2 = MachO::LoadCommands::LoadCommand.create(:LC_LOAD_DYLINKER, lc.name.to_s)
       blob = lc.view.raw_data[lc.view.offset, lc.cmdsize]
 
       assert_equal blob, lc.serialize(ctx)
@@ -161,9 +161,9 @@ class MachOLoadCommandSerializationTest < Minitest::Test
 
     filenames.each do |filename|
       file = MachO::MachOFile.new(filename)
-      ctx = MachO::LoadCommand::SerializationContext.context_for(file)
+      ctx = MachO::LoadCommands::LoadCommand::SerializationContext.context_for(file)
       lc = file[:LC_RPATH].first
-      lc2 = MachO::LoadCommand.create(:LC_RPATH, lc.path.to_s)
+      lc2 = MachO::LoadCommands::LoadCommand.create(:LC_RPATH, lc.path.to_s)
       blob = lc.view.raw_data[lc.view.offset, lc.cmdsize]
 
       assert_equal blob, lc.serialize(ctx)


### PR DESCRIPTION
Corresponds to #47.

Major changes:

Everything in *headers.rb* is now namespaced under `MachO::Headers`
Everything in *load_commands.rb* is now namespaced under `MachO::LoadCommands`.
Everything in *sections.rb* is now namespaced under `MachO::Sections`.