### PR TITLE
Support for creating universal binaries from separate single-arch Mach-Os

### DIFF
--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -470,6 +470,11 @@ module MachO
         @magic = magic
         @nfat_arch = nfat_arch
       end
+
+      # @return [String] the serialized fields of the fat header
+      def serialize
+        [magic, nfat_arch].pack(FORMAT)
+      end
     end
 
     # Fat binary header architecture structure. A Fat binary has one or more of
@@ -507,6 +512,11 @@ module MachO
         @offset = offset
         @size = size
         @align = align
+      end
+
+      # @return [String] the serialized fields of the fat arch
+      def serialize
+        [cputype, cpusubtype, offset, size, align].pack(FORMAT)
       end
     end
 

--- a/lib/macho/tools.rb
+++ b/lib/macho/tools.rb
@@ -80,5 +80,24 @@ module MachO
       file.delete_rpath(old_path, options)
       file.write!
     end
+
+    # Merge multiple Mach-Os into one universal (Fat) binary.
+    # @param filename [String] the fat binary to create
+    # @param files [Array<MachO::MachOFile, MachO::FatFile>] the files to merge
+    # @return [void]
+    def self.merge_machos(filename, *files)
+      machos = files.map do |file|
+        macho = MachO.open(file)
+        case macho
+        when MachO::MachOFile
+          macho
+        else
+          macho.machos
+        end
+      end.flatten
+
+      fat_macho = MachO::FatFile.new_from_machos(*machos)
+      fat_macho.write(filename)
+    end
   end
 end

--- a/test/test_tools.rb
+++ b/test/test_tools.rb
@@ -283,4 +283,37 @@ class MachOToolsTest < Minitest::Test
       delete_if_exists(actual)
     end
   end
+
+  def test_merge_machos
+    filenames = SINGLE_ARCHES.map { |a| fixture(a, "hello.bin") }
+    merged_filename = "merged_machos.bin"
+
+    # merge a bunch of single-arch Mach-Os and save them as a universal
+    MachO::Tools.merge_machos(merged_filename, *filenames)
+
+    # ensure that we can load the merged machos
+    file = MachO::FatFile.new(merged_filename)
+
+    assert file
+    assert_instance_of MachO::FatFile, file
+    assert_equal filenames.size, file.machos.size
+  ensure
+    delete_if_exists(merged_filename)
+  end
+
+  def test_merge_machos_fat
+    filenames = FAT_ARCH_PAIRS.map { |a| fixture(a, "hello.bin") }
+    merged_filename = "merged_universals.bin"
+
+    # merge a bunch of universal Mach-Os and save them as one universal
+    MachO::Tools.merge_machos(merged_filename, *filenames)
+
+    # ensure that we can load the merged machos
+    file = MachO::FatFile.new(merged_filename)
+
+    assert file
+    assert_instance_of MachO::FatFile, file
+  ensure
+    delete_if_exists(merged_filename)
+  end
 end


### PR DESCRIPTION
This adds `MachO::FatFile.new_from_machos(*machos)` and two serialization helper methods to support it, as well as `MachO::Tools.merge_machos(filename, *files)` as a convenience method.

It may also be nice to add a `MachO::FatFile#insert_macho` method, which would be used to merge a single-arch Mach-O into an extant `MachO::FatFile`.