### PR TITLE
General cleanup.

### DIFF
--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -16,11 +16,11 @@ module MachO
 
   # Opens the given filename as a MachOFile or FatFile, depending on its magic.
   # @param filename [String] the file being opened
-  # @return [MachO::MachOFile] if the file is a Mach-O
-  # @return [MachO::FatFile] if the file is a Fat file
+  # @return [MachOFile] if the file is a Mach-O
+  # @return [FatFile] if the file is a Fat file
   # @raise [ArgumentError] if the given file does not exist
-  # @raise [MachO::TruncatedFileError] if the file is too small to have a valid header
-  # @raise [MachO::MagicError] if the file's magic is not valid Mach-O magic
+  # @raise [TruncatedFileError] if the file is too small to have a valid header
+  # @raise [MagicError] if the file's magic is not valid Mach-O magic
   def self.open(filename)
     raise ArgumentError, "#{filename}: no such file" unless File.file?(filename)
     raise TruncatedFileError unless File.stat(filename).size >= 4

--- a/lib/macho/exceptions.rb
+++ b/lib/macho/exceptions.rb
@@ -80,7 +80,8 @@ module MachO
     # @param cputype [Fixnum] the CPU type of the unknown pair
     # @param cpusubtype [Fixnum] the CPU sub-type of the unknown pair
     def initialize(cputype, cpusubtype)
-      super "Unrecognized CPU sub-type: 0x#{"%08x" % cpusubtype} (for CPU type: 0x#{"%08x" % cputype})"
+      super "Unrecognized CPU sub-type: 0x#{"%08x" % cpusubtype}" \
+        " (for CPU type: 0x#{"%08x" % cputype})"
     end
   end
 
@@ -108,13 +109,15 @@ module MachO
     end
   end
 
-  # Raised when the number of arguments used to create a load command manually is wrong.
+  # Raised when the number of arguments used to create a load command manually
+  # is wrong.
   class LoadCommandCreationArityError < MachOError
     # @param cmd_sym [Symbol] the load command's symbol
     # @param expected_arity [Fixnum] the number of arguments expected
     # @param actual_arity [Fixnum] the number of arguments received
     def initialize(cmd_sym, expected_arity, actual_arity)
-      super "Expected #{expected_arity} arguments for #{cmd_sym} creation, got #{actual_arity}"
+      super "Expected #{expected_arity} arguments for #{cmd_sym} creation," \
+        " got #{actual_arity}"
     end
   end
 
@@ -130,7 +133,8 @@ module MachO
   class LCStrMalformedError < MachOError
     # @param lc [MachO::LoadCommand] the load command containing the string
     def initialize(lc)
-      super "Load command #{lc.type} at offset #{lc.view.offset} contains a malformed string"
+      super "Load command #{lc.type} at offset #{lc.view.offset} contains a" \
+        " malformed string"
     end
   end
 

--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -574,6 +574,71 @@ module MachO
         return false if flag.nil?
         flags & flag == flag
       end
+
+      # @return [Boolean] whether or not the file is of type `MH_OBJECT`
+      def object?
+        filetype == Headers::MH_OBJECT
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_EXECUTE`
+      def executable?
+        filetype == Headers::MH_EXECUTE
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_FVMLIB`
+      def fvmlib?
+        filetype == Headers::MH_FVMLIB
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_CORE`
+      def core?
+        filetype == Headers::MH_CORE
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_PRELOAD`
+      def preload?
+        filetype == Headers::MH_PRELOAD
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_DYLIB`
+      def dylib?
+        filetype == Headers::MH_DYLIB
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_DYLINKER`
+      def dylinker?
+        filetype == Headers::MH_DYLINKER
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_BUNDLE`
+      def bundle?
+        filetype == Headers::MH_BUNDLE
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_DSYM`
+      def dsym?
+        filetype == Headers::MH_DSYM
+      end
+
+      # @return [Boolean] whether or not the file is of type `MH_KEXT_BUNDLE`
+      def kext?
+        filetype == Headers::MH_KEXT_BUNDLE
+      end
+
+      # @return [Boolean] true if the Mach-O has 32-bit magic, false otherwise
+      def magic32?
+        Utils.magic32?(magic)
+      end
+
+      # @return [Boolean] true if the Mach-O has 64-bit magic, false otherwise
+      def magic64?
+        Utils.magic64?(magic)
+      end
+
+      # @return [Fixnum] the file's internal alignment
+      def alignment
+        magic32? ? 4 : 8
+      end
     end
 
     # 64-bit Mach-O file header structure

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -2,7 +2,7 @@ module MachO
   # Classes and constants for parsing load commands in Mach-O binaries.
   module LoadCommands
     # load commands added after OS X 10.1 need to be bitwise ORed with
-    # LC_REQ_DYLD to be recognized by the dynamic linder (dyld)
+    # LC_REQ_DYLD to be recognized by the dynamic linker (dyld)
     # @api private
     LC_REQ_DYLD = 0x80000000
 

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -5,27 +5,29 @@ module MachO
   # as well as binary executable instructions. Mach-O binaries are
   # architecture specific.
   # @see https://en.wikipedia.org/wiki/Mach-O
-  # @see MachO::FatFile
+  # @see FatFile
   class MachOFile
     extend Forwardable
 
-    # @return [String] the filename loaded from, or nil if loaded from a binary string
+    # @return [String] the filename loaded from, or nil if loaded from a binary
+    #  string
     attr_accessor :filename
 
     # @return [Symbol] the endianness of the file, :big or :little
     attr_reader :endianness
 
-    # @return [MachO::Headers::MachHeader] if the Mach-O is 32-bit
-    # @return [MachO::Headers::MachHeader64] if the Mach-O is 64-bit
+    # @return [Headers::MachHeader] if the Mach-O is 32-bit
+    # @return [Headers::MachHeader64] if the Mach-O is 64-bit
     attr_reader :header
 
-    # @return [Array<MachO::LoadCommands::LoadCommand>] an array of the file's load commands
+    # @return [Array<LoadCommands::LoadCommand>] an array of the file's load
+    #  commands
     # @note load commands are provided in order of ascending offset.
     attr_reader :load_commands
 
     # Creates a new MachOFile instance from a binary string.
     # @param bin [String] a binary string containing raw Mach-O data
-    # @return [MachO::MachOFile] a new MachOFile
+    # @return [MachOFile] a new MachOFile
     def self.new_from_bin(bin)
       instance = allocate
       instance.initialize_from_bin(bin)
@@ -123,7 +125,8 @@ module MachO
     #  file.command("LC_LOAD_DYLIB")
     #  file[:LC_LOAD_DYLIB]
     # @param [String, Symbol] name the load command ID
-    # @return [Array<MachO::LoadCommands::LoadCommand>] an array of load commands corresponding to `name`
+    # @return [Array<LoadCommands::LoadCommand>] an array of load commands
+    #  corresponding to `name`
     def command(name)
       load_commands.select { |lc| lc.type == name.to_sym }
     end
@@ -132,12 +135,12 @@ module MachO
 
     # Inserts a load command at the given offset.
     # @param offset [Fixnum] the offset to insert at
-    # @param lc [MachO::LoadCommands::LoadCommand] the load command to insert
+    # @param lc [LoadCommands::LoadCommand] the load command to insert
     # @param options [Hash]
     # @option options [Boolean] :repopulate (true) whether or not to repopulate
     #  the instance fields
-    # @raise [MachO::OffsetInsertionError] if the offset is not in the load command region
-    # @raise [MachO::HeaderPadError] if the new command exceeds the header pad buffer
+    # @raise [OffsetInsertionError] if the offset is not in the load command region
+    # @raise [HeaderPadError] if the new command exceeds the header pad buffer
     # @note Calling this method with an arbitrary offset in the load command
     #  region **will leave the object in an inconsistent state**.
     def insert_command(offset, lc, options = {})
@@ -165,10 +168,10 @@ module MachO
     end
 
     # Replace a load command with another command in the Mach-O, preserving location.
-    # @param old_lc [MachO::LoadCommands::LoadCommand] the load command being replaced
-    # @param new_lc [MachO::LoadCommands::LoadCommand] the load command being added
+    # @param old_lc [LoadCommands::LoadCommand] the load command being replaced
+    # @param new_lc [LoadCommands::LoadCommand] the load command being added
     # @return [void]
-    # @raise [MachO::HeaderPadError] if the new command exceeds the header pad buffer
+    # @raise [HeaderPadError] if the new command exceeds the header pad buffer
     # @see #insert_command
     # @note This is public, but methods like {#dylib_id=} should be preferred.
     def replace_command(old_lc, new_lc)
@@ -184,7 +187,7 @@ module MachO
     end
 
     # Appends a new load command to the Mach-O.
-    # @param lc [MachO::LoadCommands::LoadCommand] the load command being added
+    # @param lc [LoadCommands::LoadCommand] the load command being added
     # @param options [Hash]
     # @option options [Boolean] :repopulate (true) whether or not to repopulate
     #  the instance fields
@@ -199,7 +202,7 @@ module MachO
     end
 
     # Delete a load command from the Mach-O.
-    # @param lc [MachO::LoadCommands::LoadCommand] the load command being deleted
+    # @param lc [LoadCommands::LoadCommand] the load command being deleted
     # @param options [Hash]
     # @option options [Boolean] :repopulate (true) whether or not to repopulate
     #  the instance fields
@@ -233,14 +236,14 @@ module MachO
     end
 
     # All load commands responsible for loading dylibs.
-    # @return [Array<MachO::LoadCommands::DylibCommand>] an array of DylibCommands
+    # @return [Array<LoadCommands::DylibCommand>] an array of DylibCommands
     def dylib_load_commands
       load_commands.select { |lc| LoadCommands::DYLIB_LOAD_COMMANDS.include?(lc.type) }
     end
 
     # All segment load commands in the Mach-O.
-    # @return [Array<MachO::LoadCommands::SegmentCommand>] if the Mach-O is 32-bit
-    # @return [Array<MachO::LoadCommands::SegmentCommand64>] if the Mach-O is 64-bit
+    # @return [Array<LoadCommands::SegmentCommand>] if the Mach-O is 32-bit
+    # @return [Array<LoadCommands::SegmentCommand64>] if the Mach-O is 64-bit
     def segments
       if magic32?
         command(:LC_SEGMENT)
@@ -299,12 +302,12 @@ module MachO
 
     # Changes the shared library `old_name` to `new_name`
     # @example
-    #  file.change_install_name("/usr/lib/libWhatever.dylib", "/usr/local/lib/libWhatever2.dylib")
+    #  file.change_install_name("abc.dylib", "def.dylib")
     # @param old_name [String] the shared library's old name
     # @param new_name [String] the shared library's new name
     # @param _options [Hash]
     # @return [void]
-    # @raise [MachO::DylibUnknownError] if no shared library has the old name
+    # @raise [DylibUnknownError] if no shared library has the old name
     # @note `_options` is currently unused and is provided for signature
     #  compatibility with {MachO::FatFile#change_install_name}
     def change_install_name(old_name, new_name, _options = {})
@@ -334,8 +337,8 @@ module MachO
     # @param new_path [String] the new runtime path
     # @param _options [Hash]
     # @return [void]
-    # @raise [MachO::RpathUnknownError] if no such old runtime path exists
-    # @raise [MachO::RpathExistsError] if the new runtime path already exists
+    # @raise [RpathUnknownError] if no such old runtime path exists
+    # @raise [RpathExistsError] if the new runtime path already exists
     # @note `_options` is currently unused and is provided for signature
     #  compatibility with {MachO::FatFile#change_rpath}
     def change_rpath(old_path, new_path, _options = {})
@@ -357,7 +360,7 @@ module MachO
     # @param path [String] the new runtime path
     # @param _options [Hash]
     # @return [void]
-    # @raise [MachO::RpathExistsError] if the runtime path already exists
+    # @raise [RpathExistsError] if the runtime path already exists
     # @note `_options` is currently unused and is provided for signature
     #  compatibility with {MachO::FatFile#add_rpath}
     def add_rpath(path, _options = {})
@@ -375,7 +378,7 @@ module MachO
     # @param path [String] the runtime path to delete
     # @param _options [Hash]
     # @return void
-    # @raise [MachO::RpathUnknownError] if no such runtime path exists
+    # @raise [RpathUnknownError] if no such runtime path exists
     # @note `_options` is currently unused and is provided for signature
     #  compatibility with {MachO::FatFile#delete_rpath}
     def delete_rpath(path, _options = {})
@@ -390,10 +393,11 @@ module MachO
     end
 
     # All sections of the segment `segment`.
-    # @param segment [MachO::LoadCommands::SegmentCommand, MachO::LoadCommands::SegmentCommand64] the segment being inspected
-    # @return [Array<MachO::Sections::Section>] if the Mach-O is 32-bit
-    # @return [Array<MachO::Sections::Section64>] if the Mach-O is 64-bit
-    # @deprecated use {MachO::LoadCommands::SegmentCommand#sections} instead
+    # @param segment [LoadCommands::SegmentCommand, LoadCommands::SegmentCommand64]
+    #  the segment being inspected
+    # @return [Array<Sections::Section>] if the Mach-O is 32-bit
+    # @return [Array<Sections::Section64>] if the Mach-O is 64-bit
+    # @deprecated use {LoadCommands::SegmentCommand#sections} instead
     def sections(segment)
       segment.sections
     end
@@ -407,7 +411,7 @@ module MachO
 
     # Write all Mach-O data to the file used to initialize the instance.
     # @return [void]
-    # @raise [MachO::MachOError] if the instance was initialized without a file
+    # @raise [MachOError] if the instance was initialized without a file
     # @note Overwrites all data in the file!
     def write!
       if @filename.nil?
@@ -420,9 +424,9 @@ module MachO
     private
 
     # The file's Mach-O header structure.
-    # @return [MachO::Headers::MachHeader] if the Mach-O is 32-bit
-    # @return [MachO::Headers::MachHeader64] if the Mach-O is 64-bit
-    # @raise [MachO::TruncatedFileError] if the file is too small to have a valid header
+    # @return [Headers::MachHeader] if the Mach-O is 32-bit
+    # @return [Headers::MachHeader64] if the Mach-O is 64-bit
+    # @raise [TruncatedFileError] if the file is too small to have a valid header
     # @api private
     def populate_mach_header
       # the smallest Mach-O header is 28 bytes
@@ -441,8 +445,8 @@ module MachO
 
     # Read just the file's magic number and check its validity.
     # @return [Fixnum] the magic
-    # @raise [MachO::MagicError] if the magic is not valid Mach-O magic
-    # @raise [MachO::FatBinaryError] if the magic is for a Fat file
+    # @raise [MagicError] if the magic is not valid Mach-O magic
+    # @raise [FatBinaryError] if the magic is for a Fat file
     # @api private
     def populate_and_check_magic
       magic = @raw_data[0..3].unpack("N").first
@@ -457,7 +461,7 @@ module MachO
 
     # Check the file's CPU type.
     # @param cputype [Fixnum] the CPU type
-    # @raise [MachO::CPUTypeError] if the CPU type is unknown
+    # @raise [CPUTypeError] if the CPU type is unknown
     # @api private
     def check_cputype(cputype)
       raise CPUTypeError, cputype unless Headers::CPU_TYPES.key?(cputype)
@@ -465,7 +469,7 @@ module MachO
 
     # Check the file's CPU type/subtype pair.
     # @param cpusubtype [Fixnum] the CPU subtype
-    # @raise [MachO::CPUSubtypeError] if the CPU sub-type is unknown
+    # @raise [CPUSubtypeError] if the CPU sub-type is unknown
     # @api private
     def check_cpusubtype(cputype, cpusubtype)
       # Only check sub-type w/o capability bits (see `populate_mach_header`).
@@ -474,15 +478,15 @@ module MachO
 
     # Check the file's type.
     # @param filetype [Fixnum] the file type
-    # @raise [MachO::FiletypeError] if the file type is unknown
+    # @raise [FiletypeError] if the file type is unknown
     # @api private
     def check_filetype(filetype)
       raise FiletypeError, filetype unless Headers::MH_FILETYPES.key?(filetype)
     end
 
     # All load commands in the file.
-    # @return [Array<MachO::LoadCommands::LoadCommand>] an array of load commands
-    # @raise [MachO::LoadCommandError] if an unknown load command is encountered
+    # @return [Array<LoadCommands::LoadCommand>] an array of load commands
+    # @raise [LoadCommandError] if an unknown load command is encountered
     # @api private
     def populate_load_commands
       offset = header.class.bytesize
@@ -497,7 +501,7 @@ module MachO
 
         # why do I do this? i don't like declaring constants below
         # classes, and i need them to resolve...
-        klass = MachO::LoadCommands.const_get LoadCommands::LC_STRUCTURES[cmd_sym]
+        klass = LoadCommands.const_get LoadCommands::LC_STRUCTURES[cmd_sym]
         view = MachOView.new(@raw_data, endianness, offset)
         command = klass.new_from_bin(view)
 

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -59,70 +59,44 @@ module MachO
       @raw_data
     end
 
-    # @return [Boolean] true if the Mach-O has 32-bit magic, false otherwise
-    def magic32?
-      Utils.magic32?(header.magic)
-    end
-
-    # @return [Boolean] true if the Mach-O has 64-bit magic, false otherwise
-    def magic64?
-      Utils.magic64?(header.magic)
-    end
-
-    # @return [Fixnum] the file's internal alignment
-    def alignment
-      magic32? ? 4 : 8
-    end
-
-    # @return [Boolean] true if the file is of type `MH_OBJECT`, false otherwise
-    def object?
-      header.filetype == Headers::MH_OBJECT
-    end
-
-    # @return [Boolean] true if the file is of type `MH_EXECUTE`, false otherwise
-    def executable?
-      header.filetype == Headers::MH_EXECUTE
-    end
-
-    # @return [Boolean] true if the file is of type `MH_FVMLIB`, false otherwise
-    def fvmlib?
-      header.filetype == Headers::MH_FVMLIB
-    end
-
-    # @return [Boolean] true if the file is of type `MH_CORE`, false otherwise
-    def core?
-      header.filetype == Headers::MH_CORE
-    end
-
-    # @return [Boolean] true if the file is of type `MH_PRELOAD`, false otherwise
-    def preload?
-      header.filetype == Headers::MH_PRELOAD
-    end
-
-    # @return [Boolean] true if the file is of type `MH_DYLIB`, false otherwise
-    def dylib?
-      header.filetype == Headers::MH_DYLIB
-    end
-
-    # @return [Boolean] true if the file is of type `MH_DYLINKER`, false otherwise
-    def dylinker?
-      header.filetype == Headers::MH_DYLINKER
-    end
-
-    # @return [Boolean] true if the file is of type `MH_BUNDLE`, false otherwise
-    def bundle?
-      header.filetype == Headers::MH_BUNDLE
-    end
-
-    # @return [Boolean] true if the file is of type `MH_DSYM`, false otherwise
-    def dsym?
-      header.filetype == Headers::MH_DSYM
-    end
-
-    # @return [Boolean] true if the file is of type `MH_KEXT_BUNDLE`, false otherwise
-    def kext?
-      header.filetype == Headers::MH_KEXT_BUNDLE
-    end
+    # @!method magic
+    #  @return (see MachO::Headers::MachHeader#magic)
+    # @!method ncmds
+    #  @return (see MachO::Headers::MachHeader#ncmds)
+    # @!method sizeofcmds
+    #  @return (see MachO::Headers::MachHeader#sizeofcmds)
+    # @!method flags
+    #  @return (see MachO::Headers::MachHeader#flags)
+    # @!method object?
+    #  @return (see MachO::Headers::MachHeader#object?)
+    # @!method executable?
+    #  @return (see MachO::Headers::MachHeader#executable?)
+    # @!method fvmlib?
+    #  @return (see MachO::Headers::MachHeader#fvmlib?)
+    # @!method core?
+    #  @return (see MachO::Headers::MachHeader#core?)
+    # @!method preload?
+    #  @return (see MachO::Headers::MachHeader#preload?)
+    # @!method dylib?
+    #  @return (see MachO::Headers::MachHeader#dylib?)
+    # @!method dylinker?
+    #  @return (see MachO::Headers::MachHeader#dylinker?)
+    # @!method bundle?
+    #  @return (see MachO::Headers::MachHeader#bundle?)
+    # @!method dsym?
+    #  @return (see MachO::Headers::MachHeader#dsym?)
+    # @!method kext?
+    #  @return (see MachO::Headers::MachHeader#kext?)
+    # @!method magic32?
+    #  @return (see MachO::Headers::MachHeader#magic32?)
+    # @!method magic64?
+    #  @return (see MachO::Headers::MachHeader#magic64?)
+    # @!method alignment
+    #  @return (see MachO::Headers::MachHeader#alignment)
+    def_delegators :header, :magic, :ncmds, :sizeofcmds, :flags, :object?,
+                   :executable?, :fvmlib?, :core?, :preload?, :dylib?,
+                   :dylinker?, :bundle?, :dsym?, :kext?, :magic32?, :magic64?,
+                   :alignment
 
     # @return [String] a string representation of the file's magic number
     def magic_string
@@ -143,16 +117,6 @@ module MachO
     def cpusubtype
       Headers::CPU_SUBTYPES[header.cputype][header.cpusubtype]
     end
-
-    # @!method magic
-    #  @return (see MachO::Headers::MachHeader#magic)
-    # @!method ncmds
-    #  @return (see MachO::Headers::MachHeader#ncmds)
-    # @!method sizeofcmds
-    #  @return (see MachO::Headers::MachHeader#sizeofcmds)
-    # @!method flags
-    #  @return (see MachO::Headers::MachHeader#flags)
-    def_delegators :header, :magic, :ncmds, :sizeofcmds, :flags
 
     # All load commands of a given name.
     # @example

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -392,16 +392,6 @@ module MachO
       populate_fields
     end
 
-    # All sections of the segment `segment`.
-    # @param segment [LoadCommands::SegmentCommand, LoadCommands::SegmentCommand64]
-    #  the segment being inspected
-    # @return [Array<Sections::Section>] if the Mach-O is 32-bit
-    # @return [Array<Sections::Section64>] if the Mach-O is 64-bit
-    # @deprecated use {LoadCommands::SegmentCommand#sections} instead
-    def sections(segment)
-      segment.sections
-    end
-
     # Write all Mach-O data to the given filename.
     # @param filename [String] the file to write to
     # @return [void]

--- a/lib/macho/sections.rb
+++ b/lib/macho/sections.rb
@@ -72,7 +72,8 @@ module MachO
       # @return [String] the name of the section, including null pad bytes
       attr_reader :sectname
 
-      # @return [String] the name of the segment's section, including null pad bytes
+      # @return [String] the name of the segment's section, including null
+      #  pad bytes
       attr_reader :segname
 
       # @return [Fixnum] the memory address of the section
@@ -124,17 +125,19 @@ module MachO
         @reserved2 = reserved2
       end
 
-      # @return [String] the section's name, with any trailing NULL characters removed
+      # @return [String] the section's name, with any trailing NULL characters
+      #  removed
       def section_name
         sectname.delete("\x00")
       end
 
-      # @return [String] the parent segment's name, with any trailing NULL characters removed
+      # @return [String] the parent segment's name, with any trailing NULL
+      #  characters removed
       def segment_name
         segname.delete("\x00")
       end
 
-      # @return [Boolean] true if the section has no contents (i.e, `size` is 0)
+      # @return [Boolean] whether the section is empty (i.e, {size} is 0)
       def empty?
         size.zero?
       end
@@ -142,7 +145,7 @@ module MachO
       # @example
       #  puts "this section is regular" if sect.flag?(:S_REGULAR)
       # @param flag [Symbol] a section flag symbol
-      # @return [Boolean] true if `flag` is present in the section's flag field
+      # @return [Boolean] whether the flag is present in the section's {flags}
       def flag?(flag)
         flag = SECTION_FLAGS[flag]
         return false if flag.nil?

--- a/lib/macho/structure.rb
+++ b/lib/macho/structure.rb
@@ -19,7 +19,7 @@ module MachO
 
     # @param endianness [Symbol] either `:big` or `:little`
     # @param bin [String] the string to be unpacked into the new structure
-    # @return [MachO::MachOStructure] a new MachOStructure initialized with `bin`
+    # @return [MachO::MachOStructure] the resulting structure
     # @api private
     def self.new_from_bin(endianness, bin)
       format = Utils.specialize_format(self::FORMAT, endianness)

--- a/lib/macho/tools.rb
+++ b/lib/macho/tools.rb
@@ -1,5 +1,6 @@
 module MachO
-  # A collection of convenient methods for common operations on Mach-O and Fat binaries.
+  # A collection of convenient methods for common operations on Mach-O and Fat
+  # binaries.
   module Tools
     # @param filename [String] the Mach-O or Fat binary being read
     # @return [Array<String>] an array of all dylibs linked to the binary
@@ -9,7 +10,8 @@ module MachO
       file.linked_dylibs
     end
 
-    # Changes the dylib ID of a Mach-O or Fat binary, overwriting the source file.
+    # Changes the dylib ID of a Mach-O or Fat binary, overwriting the source
+    #  file.
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param new_id [String] the new dylib ID for the binary
     # @param options [Hash]
@@ -23,7 +25,8 @@ module MachO
       file.write!
     end
 
-    # Changes a shared library install name in a Mach-O or Fat binary, overwriting the source file.
+    # Changes a shared library install name in a Mach-O or Fat binary,
+    #  overwriting the source file.
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param old_name [String] the old shared library name
     # @param new_name [String] the new shared library name
@@ -38,7 +41,8 @@ module MachO
       file.write!
     end
 
-    # Changes a runtime path in a Mach-O or Fat binary, overwriting the source file.
+    # Changes a runtime path in a Mach-O or Fat binary, overwriting the source
+    #  file.
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param old_path [String] the old runtime path
     # @param new_path [String] the new runtime path
@@ -67,7 +71,8 @@ module MachO
       file.write!
     end
 
-    # Delete a runtime path from a Mach-O or Fat binary, overwriting the source file.
+    # Delete a runtime path from a Mach-O or Fat binary, overwriting the source
+    #  file.
     # @param filename [String] the Mach-O or Fat binary being modified
     # @param old_path [String] the old runtime path
     # @param options [Hash]

--- a/lib/macho/utils.rb
+++ b/lib/macho/utils.rb
@@ -13,7 +13,8 @@ module MachO
       value
     end
 
-    # Returns the number of bytes needed to pad the given size to the given alignment.
+    # Returns the number of bytes needed to pad the given size to the given
+    #  alignment.
     # @param size [Fixnum] the unpadded size
     # @param alignment [Fixnum] the number to alignment the size with
     # @return [Fixnum] the number of pad bytes required
@@ -21,7 +22,8 @@ module MachO
       round(size, alignment) - size
     end
 
-    # Converts an abstract (native-endian) String#unpack format to big or little.
+    # Converts an abstract (native-endian) String#unpack format to big or
+    #  little.
     # @param format [String] the format string being converted
     # @param endianness [Symbol] either `:big` or `:little`
     # @return [String] the converted string
@@ -31,7 +33,8 @@ module MachO
     end
 
     # Packs tagged strings into an aligned payload.
-    # @param fixed_offset [Fixnum] the baseline offset for the first packed string
+    # @param fixed_offset [Fixnum] the baseline offset for the first packed
+    #  string
     # @param alignment [Fixnum] the alignment value to use for packing
     # @param strings [Hash] the labeled strings to pack
     # @return [Array<String, Hash>] the packed string and labeled offsets
@@ -53,42 +56,42 @@ module MachO
 
     # Compares the given number to valid Mach-O magic numbers.
     # @param num [Fixnum] the number being checked
-    # @return [Boolean] true if `num` is a valid Mach-O magic number, false otherwise
+    # @return [Boolean] whether `num` is a valid Mach-O magic number
     def self.magic?(num)
       Headers::MH_MAGICS.key?(num)
     end
 
     # Compares the given number to valid Fat magic numbers.
     # @param num [Fixnum] the number being checked
-    # @return [Boolean] true if `num` is a valid Fat magic number, false otherwise
+    # @return [Boolean] whether `num` is a valid Fat magic number
     def self.fat_magic?(num)
       num == Headers::FAT_MAGIC
     end
 
     # Compares the given number to valid 32-bit Mach-O magic numbers.
     # @param num [Fixnum] the number being checked
-    # @return [Boolean] true if `num` is a valid 32-bit magic number, false otherwise
+    # @return [Boolean] whether `num` is a valid 32-bit magic number
     def self.magic32?(num)
       num == Headers::MH_MAGIC || num == Headers::MH_CIGAM
     end
 
     # Compares the given number to valid 64-bit Mach-O magic numbers.
     # @param num [Fixnum] the number being checked
-    # @return [Boolean] true if `num` is a valid 64-bit magic number, false otherwise
+    # @return [Boolean] whether `num` is a valid 64-bit magic number
     def self.magic64?(num)
       num == Headers::MH_MAGIC_64 || num == Headers::MH_CIGAM_64
     end
 
     # Compares the given number to valid little-endian magic numbers.
     # @param num [Fixnum] the number being checked
-    # @return [Boolean] true if `num` is a valid little-endian magic number, false otherwise
+    # @return [Boolean] whether `num` is a valid little-endian magic number
     def self.little_magic?(num)
       num == Headers::MH_CIGAM || num == Headers::MH_CIGAM_64
     end
 
     # Compares the given number to valid big-endian magic numbers.
     # @param num [Fixnum] the number being checked
-    # @return [Boolean] true if `num` is a valid big-endian magic number, false otherwise
+    # @return [Boolean] whether `num` is a valid big-endian magic number
     def self.big_magic?(num)
       num == Headers::MH_CIGAM || num == Headers::MH_CIGAM_64
     end


### PR DESCRIPTION
Just doing some code reduction/housework.

```
fat_file: Add delegation to header/canonical Mach-O where possible.

The "canonical" Mach-O for a fat file is just the first Mach-O,
used to obtain attributes that should be constant across all
slices.

macho_file: Add delegation to header, fix YARD errors.

load_commands: Fix typo.
```