### PR TITLE
test: Use Codecov for coverage reports

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,14 +4,17 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/FormatString:
   EnforcedStyle: percent
 
 # we prefer compact if-else-end/case-when-end alignment
-Lint/EndAlignment:
+Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
 Style/HashSyntax:
@@ -50,4 +53,7 @@ Metrics/ParameterLists:
   Enabled: false
 
 Metrics/PerceivedComplexity:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "benchmark-ips"
-  gem "coveralls", require: false
+  gem "codecov", require: false, group: :test
   gem "minitest"
   gem "rake"
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,48 +1,43 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.3.0)
+    ast (2.4.0)
     benchmark-ips (2.7.2)
-    coveralls (0.8.21)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.14.1)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.4)
-      tins (~> 1.6)
+    codecov (0.1.10)
+      json
+      simplecov
+      url
     docile (1.1.5)
     json (2.1.0)
     minitest (5.11.3)
     parallel (1.12.1)
-    parser (2.4.0.2)
-      ast (~> 2.3)
+    parser (2.5.0.2)
+      ast (~> 2.4.0)
     powerpack (0.1.1)
     rainbow (3.0.0)
     rake (12.3.0)
-    rubocop (0.52.1)
+    rubocop (0.53.0)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
+      parser (>= 2.5)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    simplecov (0.14.1)
+    simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    term-ansicolor (1.6.0)
-      tins (~> 1.0)
-    thor (0.19.4)
-    tins (1.16.3)
     unicode-display_width (1.3.0)
+    url (0.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   benchmark-ips
-  coveralls
+  codecov
   minitest
   rake
   rubocop

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ruby-macho
 
 [![Gem Version](https://badge.fury.io/rb/ruby-macho.svg)](http://badge.fury.io/rb/ruby-macho)
 [![Build Status](https://travis-ci.org/Homebrew/ruby-macho.svg?branch=master)](https://travis-ci.org/Homebrew/ruby-macho)
-[![Coverage Status](https://coveralls.io/repos/github/Homebrew/ruby-macho/badge.svg?branch=master)](https://coveralls.io/github/Homebrew/ruby-macho?branch=master)
+[![Coverage Status](https://codecov.io/gh/Homebrew/ruby-macho/branch/master/graph/badge.svg)](https://codecov.io/gh/Homebrew/ruby-macho)
 
 A Ruby library for examining and modifying Mach-O files.
 

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -1,7 +1,10 @@
-# if we're running the tests on the CI, generate a coveralls coverage report
+# if we're running the tests on the CI, generate a codecov coverage report
 if ENV["CI"]
-  require "coveralls"
-  Coveralls.wear!
+  require "simplecov"
+  SimpleCov.start
+
+  require "codecov"
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
 require "digest/sha1"


### PR DESCRIPTION
This replaces Coveralls.

cc @MikeMcQuaid