### PR TITLE
lib: #to_h support

### DIFF
--- a/lib/macho/fat_file.rb
+++ b/lib/macho/fat_file.rb
@@ -265,6 +265,15 @@ module MachO
       File.open(@filename, "wb") { |f| f.write(@raw_data) }
     end
 
+    # @return [Hash] a hash representation of this {FatFile}
+    def to_h
+      {
+        "header" => header.to_h,
+        "fat_archs" => fat_archs.map(&:to_h),
+        "machos" => machos.map(&:to_h),
+      }
+    end
+
     private
 
     # Obtain the fat header from raw file data.

--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -475,6 +475,15 @@ module MachO
       def serialize
         [magic, nfat_arch].pack(FORMAT)
       end
+
+      # @return [Hash] a hash representation of this {FatHeader}
+      def to_h
+        {
+          "magic" => magic,
+          "magic_sym" => MH_MAGICS[magic],
+          "nfat_arch" => nfat_arch,
+        }.merge super
+      end
     end
 
     # Fat binary header architecture structure. A Fat binary has one or more of
@@ -508,7 +517,7 @@ module MachO
       # @api private
       def initialize(cputype, cpusubtype, offset, size, align)
         @cputype = cputype
-        @cpusubtype = cpusubtype
+        @cpusubtype = cpusubtype & ~CPU_SUBTYPE_MASK
         @offset = offset
         @size = size
         @align = align
@@ -517,6 +526,19 @@ module MachO
       # @return [String] the serialized fields of the fat arch
       def serialize
         [cputype, cpusubtype, offset, size, align].pack(FORMAT)
+      end
+
+      # @return [Hash] a hash representation of this {FatArch}
+      def to_h
+        {
+          "cputype" => cputype,
+          "cputype_sym" => CPU_TYPES[cputype],
+          "cpusubtype" => cpusubtype,
+          "cpusubtype_sym" => CPU_SUBTYPES[cputype][cpusubtype],
+          "offset" => offset,
+          "size" => size,
+          "align" => align,
+        }.merge super
       end
     end
 
@@ -639,6 +661,24 @@ module MachO
       def alignment
         magic32? ? 4 : 8
       end
+
+      # @return [Hash] a hash representation of this {MachHeader}
+      def to_h
+        {
+          "magic" => magic,
+          "magic_sym" => MH_MAGICS[magic],
+          "cputype" => cputype,
+          "cputype_sym" => CPU_TYPES[cputype],
+          "cpusubtype" => cpusubtype,
+          "cpusubtype_sym" => CPU_SUBTYPES[cputype][cpusubtype],
+          "filetype" => filetype,
+          "filetype_sym" => MH_FILETYPES[filetype],
+          "ncmds" => ncmds,
+          "sizeofcmds" => sizeofcmds,
+          "flags" => flags,
+          "alignment" => alignment,
+        }.merge super
+      end
     end
 
     # 64-bit Mach-O file header structure
@@ -659,6 +699,13 @@ module MachO
                      flags, reserved)
         super(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags)
         @reserved = reserved
+      end
+
+      # @return [Hash] a hash representation of this {MachHeader64}
+      def to_h
+        {
+          "reserved" => reserved,
+        }.merge super
       end
     end
   end

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -266,6 +266,17 @@ module MachO
         type.to_s
       end
 
+      # @return [Hash] a hash representation of this load command
+      # @note Children should override this to include additional information.
+      def to_h
+        {
+          "view" => view.to_h,
+          "cmd" => cmd,
+          "cmdsize" => cmdsize,
+          "type" => type,
+        }.merge super
+      end
+
       # Represents a Load Command string. A rough analogue to the lc_str
       # struct used internally by OS X. This class allows ruby-macho to
       # pretend that strings stored in LCs are immediately available without
@@ -304,6 +315,14 @@ module MachO
         #  load command
         def to_i
           @string_offset
+        end
+
+        # @return [Hash] a hash representation of this {LCStr}.
+        def to_h
+          {
+            "string" => to_s,
+            "offset" => to_i,
+          }
         end
       end
 
@@ -364,6 +383,14 @@ module MachO
         ]
 
         segs.join("-")
+      end
+
+      # @return [Hash] returns a hash representation of this {UUIDCommand}
+      def to_h
+        {
+          "uuid" => uuid,
+          "uuid_string" => uuid_string,
+        }.merge super
       end
     end
 
@@ -449,6 +476,22 @@ module MachO
         return false if flag.nil?
         flags & flag == flag
       end
+
+      # @return [Hash] a hash representation of this {SegmentCommand}
+      def to_h
+        {
+          "segname" => segname,
+          "vmaddr" => vmaddr,
+          "vmsize" => vmsize,
+          "fileoff" => fileoff,
+          "filesize" => filesize,
+          "maxprot" => maxprot,
+          "initprot" => initprot,
+          "nsects" => nsects,
+          "flags" => flags,
+          "sections" => sections.map(&:to_h),
+        }.merge super
+      end
     end
 
     # A load command indicating that part of this file is to be mapped into
@@ -511,6 +554,16 @@ module MachO
         [cmd, cmdsize, string_offsets[:name], timestamp, current_version,
          compatibility_version].pack(format) + string_payload
       end
+
+      # @return [Hash] a hash representation of this {DylibCommand}
+      def to_h
+        {
+          "name" => name.to_h,
+          "timestamp" => timestamp,
+          "current_version" => current_version,
+          "compatibility_version" => compatibility_version,
+        }.merge super
+      end
     end
 
     # A load command representing some aspect of the dynamic linker, depending
@@ -547,6 +600,13 @@ module MachO
         cmdsize = SIZEOF + string_payload.bytesize
         [cmd, cmdsize, string_offsets[:name]].pack(format) + string_payload
       end
+
+      # @return [Hash] a hash representation of this {DylinkerCommand}
+      def to_h
+        {
+          "name" => name.to_h,
+        }.merge super
+      end
     end
 
     # A load command used to indicate dynamic libraries used in prebinding.
@@ -576,6 +636,15 @@ module MachO
         @name = LCStr.new(self, name)
         @nmodules = nmodules
         @linked_modules = linked_modules
+      end
+
+      # @return [Hash] a hash representation of this {PreboundDylibCommand}
+      def to_h
+        {
+          "name" => name.to_h,
+          "nmodules" => nmodules,
+          "linked_modules" => linked_modules,
+        }.merge super
       end
     end
 
@@ -642,6 +711,20 @@ module MachO
         @reserved5 = reserved5
         @reserved6 = reserved6
       end
+
+      # @return [Hash] a hash representation of this {RoutinesCommand}
+      def to_h
+        {
+          "init_address" => init_address,
+          "init_module" => init_module,
+          "reserved1" => reserved1,
+          "reserved2" => reserved2,
+          "reserved3" => reserved3,
+          "reserved4" => reserved4,
+          "reserved5" => reserved5,
+          "reserved6" => reserved6,
+        }.merge super
+      end
     end
 
     # A load command containing the address of the dynamic shared library
@@ -676,6 +759,13 @@ module MachO
         super(view, cmd, cmdsize)
         @umbrella = LCStr.new(self, umbrella)
       end
+
+      # @return [Hash] a hash representation of this {SubFrameworkCommand}
+      def to_h
+        {
+          "umbrella" => umbrella.to_h,
+        }.merge super
+      end
     end
 
     # A load command signifying membership of a subumbrella containing the name
@@ -696,6 +786,13 @@ module MachO
       def initialize(view, cmd, cmdsize, sub_umbrella)
         super(view, cmd, cmdsize)
         @sub_umbrella = LCStr.new(self, sub_umbrella)
+      end
+
+      # @return [Hash] a hash representation of this {SubUmbrellaCommand}
+      def to_h
+        {
+          "sub_umbrella" => sub_umbrella.to_h,
+        }.merge super
       end
     end
 
@@ -718,6 +815,13 @@ module MachO
         super(view, cmd, cmdsize)
         @sub_library = LCStr.new(self, sub_library)
       end
+
+      # @return [Hash] a hash representation of this {SubLibraryCommand}
+      def to_h
+        {
+          "sub_library" => sub_library.to_h,
+        }.merge super
+      end
     end
 
     # A load command signifying a shared library that is a subframework of
@@ -739,6 +843,13 @@ module MachO
         super(view, cmd, cmdsize)
         @sub_client = LCStr.new(self, sub_client)
       end
+
+      # @return [Hash] a hash representation of this {SubClientCommand}
+      def to_h
+        {
+          "sub_client" => sub_client.to_h,
+        }.merge super
+      end
     end
 
     # A load command containing the offsets and sizes of the link-edit 4.3BSD
@@ -750,10 +861,10 @@ module MachO
       # @return [Integer] the number of symbol table entries
       attr_reader :nsyms
 
-      # @return the string table's offset
+      # @return [Integer] the string table's offset
       attr_reader :stroff
 
-      # @return the string table size in bytes
+      # @return [Integer] the string table size in bytes
       attr_reader :strsize
 
       # @see MachOStructure::FORMAT
@@ -771,6 +882,16 @@ module MachO
         @nsyms = nsyms
         @stroff = stroff
         @strsize = strsize
+      end
+
+      # @return [Hash] a hash representation of this {SymtabCommand}
+      def to_h
+        {
+          "symoff" => symoff,
+          "nsyms" => nsyms,
+          "stroff" => stroff,
+          "strsize" => strsize,
+        }.merge super
       end
     end
 
@@ -865,6 +986,30 @@ module MachO
         @locreloff = locreloff
         @nlocrel = nlocrel
       end
+
+      # @return [Hash] a hash representation of this {DysymtabCommand}
+      def to_h
+        {
+          "ilocalsym" => ilocalsym,
+          "nlocalsym" => nlocalsym,
+          "iextdefsym" => iextdefsym,
+          "nextdefsym" => nextdefsym,
+          "iundefsym" => iundefsym,
+          "nundefsym" => nundefsym,
+          "tocoff" => tocoff,
+          "ntoc" => ntoc,
+          "modtaboff" => modtaboff,
+          "nmodtab" => nmodtab,
+          "extrefsymoff" => extrefsymoff,
+          "nextrefsyms" => nextrefsyms,
+          "indirectsymoff" => indirectsymoff,
+          "nindirectsyms" => nindirectsyms,
+          "extreloff" => extreloff,
+          "nextrel" => nextrel,
+          "locreloff" => locreloff,
+          "nlocrel" => nlocrel,
+        }.merge super
+      end
     end
 
     # A load command containing the offset and number of hints in the two-level
@@ -894,6 +1039,15 @@ module MachO
         @htoffset = htoffset
         @nhints = nhints
         @table = TwolevelHintsTable.new(view, htoffset, nhints)
+      end
+
+      # @return [Hash] a hash representation of this {TwolevelHintsCommand}
+      def to_h
+        {
+          "htoffset" => htoffset,
+          "nhints" => nhints,
+          "table" => table.hints.map(&:to_h),
+        }.merge super
       end
 
       # A representation of the two-level namespace lookup hints table exposed
@@ -928,6 +1082,14 @@ module MachO
             @isub_image = blob >> 24
             @itoc = blob & 0x00FFFFFF
           end
+
+          # @return [Hash] a hash representation of this {TwolevelHint}
+          def to_h
+            {
+              "isub_image" => isub_image,
+              "itoc" => itoc,
+            }
+          end
         end
       end
     end
@@ -950,6 +1112,13 @@ module MachO
       def initialize(view, cmd, cmdsize, cksum)
         super(view, cmd, cmdsize)
         @cksum = cksum
+      end
+
+      # @return [Hash] a hash representation of this {PrebindCksumCommand}
+      def to_h
+        {
+          "cksum" => cksum,
+        }.merge super
       end
     end
 
@@ -985,6 +1154,13 @@ module MachO
         cmdsize = SIZEOF + string_payload.bytesize
         [cmd, cmdsize, string_offsets[:path]].pack(format) + string_payload
       end
+
+      # @return [Hash] a hash representation of this {RpathCommand}
+      def to_h
+        {
+          "path" => path.to_h,
+        }.merge super
+      end
     end
 
     # A load command representing the offsets and sizes of a blob of data in
@@ -1011,6 +1187,14 @@ module MachO
         super(view, cmd, cmdsize)
         @dataoff = dataoff
         @datasize = datasize
+      end
+
+      # @return [Hash] a hash representation of this {LinkeditDataCommand}
+      def to_h
+        {
+          "dataoff" => dataoff,
+          "datasize" => datasize,
+        }.merge super
       end
     end
 
@@ -1041,20 +1225,20 @@ module MachO
         @cryptsize = cryptsize
         @cryptid = cryptid
       end
+
+      # @return [Hash] a hash representation of this {EncryptionInfoCommand}
+      def to_h
+        {
+          "cryptoff" => cryptoff,
+          "cryptsize" => cryptsize,
+          "cryptid" => cryptid,
+        }.merge super
+      end
     end
 
     # A load command representing the offset to and size of an encrypted
     # segment. Corresponds to LC_ENCRYPTION_INFO_64.
-    class EncryptionInfoCommand64 < LoadCommand
-      # @return [Integer] the offset to the encrypted segment
-      attr_reader :cryptoff
-
-      # @return [Integer] the size of the encrypted segment
-      attr_reader :cryptsize
-
-      # @return [Integer] the encryption system, or 0 if not encrypted yet
-      attr_reader :cryptid
-
+    class EncryptionInfoCommand64 < EncryptionInfoCommand
       # @return [Integer] 64-bit padding value
       attr_reader :pad
 
@@ -1068,11 +1252,15 @@ module MachO
 
       # @api private
       def initialize(view, cmd, cmdsize, cryptoff, cryptsize, cryptid, pad)
-        super(view, cmd, cmdsize)
-        @cryptoff = cryptoff
-        @cryptsize = cryptsize
-        @cryptid = cryptid
+        super(view, cmd, cmdsize, cryptoff, cryptsize, cryptid)
         @pad = pad
+      end
+
+      # @return [Hash] a hash representation of this {EncryptionInfoCommand64}
+      def to_h
+        {
+          "pad" => pad,
+        }.merge super
       end
     end
 
@@ -1122,6 +1310,16 @@ module MachO
 
         segs.join(".")
       end
+
+      # @return [Hash] a hash representation of this {VersionMinCommand}
+      def to_h
+        {
+          "version" => version,
+          "version_string" => version_string,
+          "sdk" => sdk,
+          "sdk_string" => sdk_string,
+        }.merge super
+      end
     end
 
     # A load command containing the minimum OS version on which
@@ -1157,6 +1355,40 @@ module MachO
         @tool_entries = ToolEntries.new(view, ntools)
       end
 
+      # A string representation of the binary's minimum OS version.
+      # @return [String] a string representing the minimum OS version.
+      def minos_string
+        binary = "%032b" % minos
+        segs = [
+          binary[0..15], binary[16..23], binary[24..31]
+        ].map { |s| s.to_i(2) }
+
+        segs.join(".")
+      end
+
+      # A string representation of the binary's SDK version.
+      # @return [String] a string representing the SDK version.
+      def sdk_string
+        binary = "%032b" % sdk
+        segs = [
+          binary[0..15], binary[16..23], binary[24..31]
+        ].map { |s| s.to_i(2) }
+
+        segs.join(".")
+      end
+
+      # @return [Hash] a hash representation of this {BuildVersionCommand}
+      def to_h
+        {
+          "platform" => platform,
+          "minos" => minos,
+          "minos_string" => minos_string,
+          "sdk" => sdk,
+          "sdk_string" => sdk_string,
+          "tool_entries" => tool_entries.tools.map(&:to_h),
+        }.merge super
+      end
+
       # A representation of the tool versions exposed
       # by a {BuildVersionCommand} (`LC_BUILD_VERSION`).
       class ToolEntries
@@ -1182,36 +1414,22 @@ module MachO
           # @return [Integer] the tool's version number
           attr_reader :version
 
-          # @param tool 32-bit integer
-          # # @param version 32-bit integer
+          # @param tool [Integer] 32-bit integer
+          # @param version [Integer] 32-bit integer
           # @api private
           def initialize(tool, version)
             @tool = tool
             @version = version
           end
+
+          # @return [Hash] a hash representation of this {Tool}
+          def to_h
+            {
+              "tool" => tool,
+              "version" => version,
+            }
+          end
         end
-      end
-
-      # A string representation of the binary's minimum OS version.
-      # @return [String] a string representing the minimum OS version.
-      def minos_string
-        binary = "%032b" % minos
-        segs = [
-          binary[0..15], binary[16..23], binary[24..31]
-        ].map { |s| s.to_i(2) }
-
-        segs.join(".")
-      end
-
-      # A string representation of the binary's SDK version.
-      # @return [String] a string representing the SDK version.
-      def sdk_string
-        binary = "%032b" % sdk
-        segs = [
-          binary[0..15], binary[16..23], binary[24..31]
-        ].map { |s| s.to_i(2) }
-
-        segs.join(".")
       end
     end
 
@@ -1273,6 +1491,22 @@ module MachO
         @export_off = export_off
         @export_size = export_size
       end
+
+      # @return [Hash] a hash representation of this {DyldInfoCommand}
+      def to_h
+        {
+          "rebase_off" => rebase_off,
+          "rebase_size" => rebase_size,
+          "bind_off" => bind_off,
+          "bind_size" => bind_size,
+          "weak_bind_off" => weak_bind_off,
+          "weak_bind_size" => weak_bind_size,
+          "lazy_bind_off" => lazy_bind_off,
+          "lazy_bind_size" => lazy_bind_size,
+          "export_off" => export_off,
+          "export_size" => export_size,
+        }.merge super
+      end
     end
 
     # A load command containing linker options embedded in object files.
@@ -1293,6 +1527,13 @@ module MachO
       def initialize(view, cmd, cmdsize, count)
         super(view, cmd, cmdsize)
         @count = count
+      end
+
+      # @return [Hash] a hash representation of this {LinkerOptionCommand}
+      def to_h
+        {
+          "count" => count,
+        }.merge super
       end
     end
 
@@ -1317,6 +1558,14 @@ module MachO
         super(view, cmd, cmdsize)
         @entryoff = entryoff
         @stacksize = stacksize
+      end
+
+      # @return [Hash] a hash representation of this {EntryPointCommand}
+      def to_h
+        {
+          "entryoff" => entryoff,
+          "stacksize" => stacksize,
+        }.merge super
       end
     end
 
@@ -1351,6 +1600,14 @@ module MachO
 
         segs.join(".")
       end
+
+      # @return [Hash] a hash representation of this {SourceVersionCommand}
+      def to_h
+        {
+          "version" => version,
+          "version_string" => version_string,
+        }.merge super
+      end
     end
 
     # An obsolete load command containing the offset and size of the (GNU style)
@@ -1375,6 +1632,14 @@ module MachO
         super(view, cmd, cmdsize)
         @offset = offset
         @size = size
+      end
+
+      # @return [Hash] a hash representation of this {SymsegCommand}
+      def to_h
+        {
+          "offset" => offset,
+          "size" => size,
+        }.merge super
       end
     end
 
@@ -1413,6 +1678,14 @@ module MachO
         @name = LCStr.new(self, name)
         @header_addr = header_addr
       end
+
+      # @return [Hash] a hash representation of this {FvmfileCommand}
+      def to_h
+        {
+          "name" => name.to_h,
+          "header_addr" => header_addr,
+        }.merge super
+      end
     end
 
     # An obsolete load command containing the path to a library to be loaded
@@ -1441,6 +1714,15 @@ module MachO
         @minor_version = minor_version
         @header_addr = header_addr
       end
+
+      # @return [Hash] a hash representation of this {FvmlibCommand}
+      def to_h
+        {
+          "name" => name.to_h,
+          "minor_version" => minor_version,
+          "header_addr" => header_addr,
+        }.merge super
+      end
     end
 
     # A load command containing an owner name and offset/size for an arbitrary data region.
@@ -1468,6 +1750,15 @@ module MachO
         @data_owner = data_owner
         @offset = offset
         @size = size
+      end
+
+      # @return [Hash] a hash representation of this {NoteCommand}
+      def to_h
+        {
+          "data_owner" => data_owner,
+          "offset" => offset,
+          "size" => size,
+        }.merge super
       end
     end
   end

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -408,6 +408,14 @@ module MachO
       File.open(@filename, "wb") { |f| f.write(@raw_data) }
     end
 
+    # @return [Hash] a hash representation of this {MachOFile}
+    def to_h
+      {
+        "header" => header.to_h,
+        "load_commands" => load_commands.map(&:to_h),
+      }
+    end
+
     private
 
     # The file's Mach-O header structure.

--- a/lib/macho/sections.rb
+++ b/lib/macho/sections.rb
@@ -149,6 +149,23 @@ module MachO
         return false if flag.nil?
         flags & flag == flag
       end
+
+      # @return [Hash] a hash representation of this {Section}
+      def to_h
+        {
+          "sectname" => sectname,
+          "segname" => segname,
+          "addr" => addr,
+          "size" => size,
+          "offset" => offset,
+          "align" => align,
+          "reloff" => reloff,
+          "nreloc" => nreloc,
+          "flags" => flags,
+          "reserved1" => reserved1,
+          "reserved2" => reserved2,
+        }.merge super
+      end
     end
 
     # Represents a section of a segment for 64-bit architectures.
@@ -168,6 +185,13 @@ module MachO
         super(sectname, segname, addr, size, offset, align, reloff,
           nreloc, flags, reserved1, reserved2)
         @reserved3 = reserved3
+      end
+
+      # @return [Hash] a hash representation of this {Section64}
+      def to_h
+        {
+          "reserved3" => reserved3,
+        }.merge super
       end
     end
   end

--- a/lib/macho/structure.rb
+++ b/lib/macho/structure.rb
@@ -26,5 +26,15 @@ module MachO
 
       new(*bin.unpack(format))
     end
+
+    # @return [Hash] a hash representation of this {MachOStructure}.
+    def to_h
+      {
+        "structure" => {
+          "format" => self.class::FORMAT,
+          "bytesize" => self.class.bytesize,
+        },
+      }
+    end
   end
 end

--- a/lib/macho/view.rb
+++ b/lib/macho/view.rb
@@ -19,5 +19,13 @@ module MachO
       @endianness = endianness
       @offset = offset
     end
+
+    # @return [Hash] a hash representation of this {MachOView}.
+    def to_h
+      {
+        "endianness" => endianness,
+        "offset" => offset,
+      }
+    end
   end
 end


### PR DESCRIPTION
This commit adds support for `#to_h` to core ruby-macho classes.

TODO:

- [x] implement `#to_h` for individual `LoadCommand` subclasses
- [x] unit tests