### PR TITLE
Apply an ad-hoc signature after modifying IDs

### DIFF
--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -49,7 +49,7 @@ module MachO
   # @raise [ModificationError] if the operation fails
   def self.codesign(filename)
     # codesign binary is not available on Linux
-    return unless RUBY_PLATFORM =~ /darwin/
+    return if RUBY_PLATFORM !~ /darwin/
     raise ArgumentError, "#{filename}: no such file" unless File.file?(filename)
 
     system("codesign", "--sign", "-", "--force",

--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -47,7 +47,7 @@ module MachO
   # @param filename [String] the file being opened
   # @return [void]
   # @raise [ModificationError] if the operation fails
-  def self.codesign(filename)
+  def self.codesign!(filename)
     # codesign binary is not available on Linux
     return if RUBY_PLATFORM !~ /darwin/
     raise ArgumentError, "#{filename}: no such file" unless File.file?(filename)

--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "English"
 require_relative "macho/structure"
 require_relative "macho/view"
 require_relative "macho/headers"
@@ -38,5 +39,23 @@ module MachO
     end
 
     file
+  end
+
+  # Signs the dylib using an ad-hoc identity.
+  # Necessary after making any changes to a dylib, since otherwise
+  # changing a signed file invalidates its signature.
+  # @param filename [String] the file being opened
+  # @return [void]
+  # @raise [ModificationError] if the operation fails
+  def self.codesign(filename)
+    # codesign binary is not available on Linux
+    return unless RUBY_PLATFORM =~ /darwin/
+    raise ArgumentError, "#{filename}: no such file" unless File.file?(filename)
+
+    system("codesign", "--sign", "-", "--force",
+           "--preserve-metadata=entitlements,requirements,flags,runtime",
+           filename)
+
+    raise ModificationError, "#{filename}: signing failed!" unless $CHILD_STATUS.success?
   end
 end

--- a/lib/macho/tools.rb
+++ b/lib/macho/tools.rb
@@ -26,7 +26,7 @@ module MachO
       file.change_dylib_id(new_id, options)
       file.write!
 
-      MachO.codesign(filename)
+      MachO.codesign!(filename)
     end
 
     # Changes a shared library install name in a Mach-O or Fat binary,
@@ -44,7 +44,7 @@ module MachO
       file.change_install_name(old_name, new_name, options)
       file.write!
 
-      MachO.codesign(filename)
+      MachO.codesign!(filename)
     end
 
     # Changes a runtime path in a Mach-O or Fat binary, overwriting the source
@@ -62,7 +62,7 @@ module MachO
       file.change_rpath(old_path, new_path, options)
       file.write!
 
-      MachO.codesign(filename)
+      MachO.codesign!(filename)
     end
 
     # Add a runtime path to a Mach-O or Fat binary, overwriting the source file.
@@ -78,7 +78,7 @@ module MachO
       file.add_rpath(new_path, options)
       file.write!
 
-      MachO.codesign(filename)
+      MachO.codesign!(filename)
     end
 
     # Delete a runtime path from a Mach-O or Fat binary, overwriting the source
@@ -95,7 +95,7 @@ module MachO
       file.delete_rpath(old_path, options)
       file.write!
 
-      MachO.codesign(filename)
+      MachO.codesign!(filename)
     end
 
     # Merge multiple Mach-Os into one universal (Fat) binary.
@@ -117,7 +117,7 @@ module MachO
       fat_macho = MachO::FatFile.new_from_machos(*machos, :fat64 => fat64)
       fat_macho.write(filename)
 
-      MachO.codesign(filename)
+      MachO.codesign!(filename)
     end
   end
 end

--- a/lib/macho/tools.rb
+++ b/lib/macho/tools.rb
@@ -25,6 +25,8 @@ module MachO
 
       file.change_dylib_id(new_id, options)
       file.write!
+
+      MachO.codesign(filename)
     end
 
     # Changes a shared library install name in a Mach-O or Fat binary,
@@ -41,6 +43,8 @@ module MachO
 
       file.change_install_name(old_name, new_name, options)
       file.write!
+
+      MachO.codesign(filename)
     end
 
     # Changes a runtime path in a Mach-O or Fat binary, overwriting the source
@@ -57,6 +61,8 @@ module MachO
 
       file.change_rpath(old_path, new_path, options)
       file.write!
+
+      MachO.codesign(filename)
     end
 
     # Add a runtime path to a Mach-O or Fat binary, overwriting the source file.
@@ -71,6 +77,8 @@ module MachO
 
       file.add_rpath(new_path, options)
       file.write!
+
+      MachO.codesign(filename)
     end
 
     # Delete a runtime path from a Mach-O or Fat binary, overwriting the source
@@ -86,6 +94,8 @@ module MachO
 
       file.delete_rpath(old_path, options)
       file.write!
+
+      MachO.codesign(filename)
     end
 
     # Merge multiple Mach-Os into one universal (Fat) binary.
@@ -106,6 +116,8 @@ module MachO
 
       fat_macho = MachO::FatFile.new_from_machos(*machos, :fat64 => fat64)
       fat_macho.write(filename)
+
+      MachO.codesign(filename)
     end
   end
 end


### PR DESCRIPTION
If we make any changes to a signed binary, we invalidate the signature. Without resigning, the resulting binary is unusable. To my knowledge, there's no disadvantage to signing an unsigned binary using an ad-hoc signature, so we can just do this unconditionally to ensure we don't end up creating bad binaries. The ad-hoc signature should always be available and always work, so this should be safe to do in all circumstances.

I do still need to confirm which OS versions this will work with.