### PR TITLE
MachO: downgrade codesigning failures to a warning

### DIFF
--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -56,6 +56,6 @@ module MachO
            "--preserve-metadata=entitlements,requirements,flags,runtime",
            filename)
 
-    raise ModificationError, "#{filename}: signing failed!" unless $CHILD_STATUS.success?
+    raise CodeSigningError, "#{filename}: signing failed!" unless $CHILD_STATUS.success?
   end
 end

--- a/lib/macho/exceptions.rb
+++ b/lib/macho/exceptions.rb
@@ -9,6 +9,11 @@ module MachO
   class ModificationError < MachOError
   end
 
+  # Raised when codesigning fails. Certain environments
+  # may want to rescue this to treat it as non-fatal.
+  class CodeSigningError < MachOError
+  end
+
   # Raised when a Mach-O file modification fails but can be recovered when
   # operating on multiple Mach-O slices of a fat binary in non-strict mode.
   class RecoverableModificationError < ModificationError


### PR DESCRIPTION
This turned out to cause problems with certain exotic dylibs. Leaving this a warning should be safer instead.

refs https://github.com/Homebrew/brew/issues/8922