### PR TITLE
macho: require `codesign!` call to be done explicitly.

### DIFF
--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -49,8 +49,7 @@ module MachO
   # @return [void]
   # @raise [ModificationError] if the operation fails
   def self.codesign!(filename)
-    # codesign binary is not available on Linux
-    return if RUBY_PLATFORM !~ /darwin/
+    raise ArgumentError, "codesign binary is not available on Linux" if RUBY_PLATFORM !~ /darwin/
     raise ArgumentError, "#{filename}: no such file" unless File.file?(filename)
 
     _, _, status = Open3.capture3("codesign", "--sign", "-", "--force",

--- a/lib/macho/tools.rb
+++ b/lib/macho/tools.rb
@@ -25,8 +25,6 @@ module MachO
 
       file.change_dylib_id(new_id, options)
       file.write!
-
-      MachO.codesign!(filename)
     end
 
     # Changes a shared library install name in a Mach-O or Fat binary,
@@ -43,8 +41,6 @@ module MachO
 
       file.change_install_name(old_name, new_name, options)
       file.write!
-
-      MachO.codesign!(filename)
     end
 
     # Changes a runtime path in a Mach-O or Fat binary, overwriting the source
@@ -61,8 +57,6 @@ module MachO
 
       file.change_rpath(old_path, new_path, options)
       file.write!
-
-      MachO.codesign!(filename)
     end
 
     # Add a runtime path to a Mach-O or Fat binary, overwriting the source file.
@@ -77,8 +71,6 @@ module MachO
 
       file.add_rpath(new_path, options)
       file.write!
-
-      MachO.codesign!(filename)
     end
 
     # Delete a runtime path from a Mach-O or Fat binary, overwriting the source
@@ -94,8 +86,6 @@ module MachO
 
       file.delete_rpath(old_path, options)
       file.write!
-
-      MachO.codesign!(filename)
     end
 
     # Merge multiple Mach-Os into one universal (Fat) binary.
@@ -116,8 +106,6 @@ module MachO
 
       fat_macho = MachO::FatFile.new_from_machos(*machos, :fat64 => fat64)
       fat_macho.write(filename)
-
-      MachO.codesign!(filename)
     end
   end
 end


### PR DESCRIPTION
As explained in https://github.com/Homebrew/brew/pull/9040#issuecomment-723888003 I think it's more desirable to have the `codesign!` calls happen inside Homebrew/brew instead of inside `macho/tools` methods.

This makes it easier for Homebrew to turn this functionality on/off, change what platforms are affected, etc. without needing to tag and vendor a new release each time.