### PR TITLE
Delete rpaths one at a time

### DIFF
--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -415,11 +415,10 @@ module MachO
     # @note `_options` is currently unused and is provided for signature
     #  compatibility with {MachO::FatFile#delete_rpath}
     def delete_rpath(path, _options = {})
-      rpath_cmds = command(:LC_RPATH).select { |r| r.path.to_s == path }
-      raise RpathUnknownError, path if rpath_cmds.empty?
+      rpath_cmd = command(:LC_RPATH).find { |r| r.path.to_s == path }
+      raise RpathUnknownError, path unless rpath_cmd
 
-      # delete the commands in reverse order, offset descending.
-      rpath_cmds.reverse_each { |cmd| delete_command(cmd) }
+      delete_command(rpath_cmd)
     end
 
     # Write all Mach-O data to the given filename.

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -451,14 +451,19 @@ class MachOFileTest < Minitest::Test
       file = MachO::MachOFile.new(filename)
 
       refute_empty file.rpaths
-      orig_ncmds = file.ncmds
+      orig_ncmds = current_ncmds = file.ncmds
       orig_sizeofcmds = file.sizeofcmds
-      orig_npaths = file.rpaths.size
+      orig_npaths = current_npaths = file.rpaths.size
 
-      file.rpaths.each { |rpath| file.delete_rpath(rpath) }
-      assert_operator file.ncmds, :<, orig_ncmds
-      assert_operator file.sizeofcmds, :<, orig_sizeofcmds
-      assert_operator file.rpaths.size, :<, orig_npaths
+      file.rpaths.each do |rpath|
+        file.delete_rpath(rpath)
+        current_npaths -= 1
+        current_ncmds -= 1
+
+        assert_equal file.ncmds, current_ncmds
+        assert_equal file.rpaths.size, current_npaths
+        assert_operator file.sizeofcmds, :<, orig_sizeofcmds
+      end
 
       file.write(actual)
       # ensure we can actually re-load and parse the modified file

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -455,7 +455,7 @@ class MachOFileTest < Minitest::Test
       orig_sizeofcmds = file.sizeofcmds
       orig_npaths = file.rpaths.size
 
-      file.delete_rpath(file.rpaths.first)
+      file.rpaths.each { |rpath| file.delete_rpath(rpath) }
       assert_operator file.ncmds, :<, orig_ncmds
       assert_operator file.sizeofcmds, :<, orig_sizeofcmds
       assert_operator file.rpaths.size, :<, orig_npaths


### PR DESCRIPTION
Since `delete_rpath` differs from the behaviour of `otool` in that
duplicate rpaths are deleted in a single invocation, we should be
consistent with that and not report duplicates even when they exist.

Otherwise, this can break workflows that iterate through a macho-o
file's rpaths and does something with each of them. I currently have a
workaround for this in brew [1], but I realised this should actually
probably be fixed here.

[1] https://github.com/Homebrew/brew/pull/11392