### PR TITLE
sections: add `Section#type?` and `Section#attribute?`

### DIFF
--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -175,6 +175,7 @@ module MachO
       :SG_FVMLIB => 0x2,
       :SG_NORELOC => 0x4,
       :SG_PROTECTED_VERSION_1 => 0x8,
+      :SG_READ_ONLY => 0x10,
     }.freeze
 
     # The top-level Mach-O load command structure.

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -611,8 +611,8 @@ module MachO
       segments.each do |seg|
         seg.sections.each do |sect|
           next if sect.empty?
-          next if sect.flag?(:S_ZEROFILL)
-          next if sect.flag?(:S_THREAD_LOCAL_ZEROFILL)
+          next if sect.type?(:S_ZEROFILL)
+          next if sect.type?(:S_THREAD_LOCAL_ZEROFILL)
           next unless sect.offset < offset
 
           offset = sect.offset

--- a/lib/macho/sections.rb
+++ b/lib/macho/sections.rb
@@ -4,10 +4,10 @@ module MachO
   # Classes and constants for parsing sections in Mach-O binaries.
   module Sections
     # type mask
-    SECTION_TYPE = 0x000000ff
+    SECTION_TYPE_MASK = 0x000000ff
 
     # attributes mask
-    SECTION_ATTRIBUTES = 0xffffff00
+    SECTION_ATTRIBUTES_MASK = 0xffffff00
 
     # user settable attributes mask
     SECTION_ATTRIBUTES_USR = 0xff000000
@@ -19,9 +19,9 @@ module MachO
     # @note see `MAXSECTALIGN` macro in `cctools/misc/lipo.c`
     MAX_SECT_ALIGN = 15
 
-    # association of section flag symbols to values
+    # association of section type symbols to values
     # @api private
-    SECTION_FLAGS = {
+    SECTION_TYPES = {
       :S_REGULAR => 0x0,
       :S_ZEROFILL => 0x1,
       :S_CSTRING_LITERALS => 0x2,
@@ -44,6 +44,12 @@ module MachO
       :S_THREAD_LOCAL_VARIABLES => 0x13,
       :S_THREAD_LOCAL_VARIABLE_POINTERS => 0x14,
       :S_THREAD_LOCAL_INIT_FUNCTION_POINTERS => 0x15,
+      :S_INIT_FUNC_OFFSETS => 0x16,
+    }.freeze
+
+    # association of section attribute symbols to values
+    # @api private
+    SECTION_ATTRIBUTES = {
       :S_ATTR_PURE_INSTRUCTIONS => 0x80000000,
       :S_ATTR_NO_TOC => 0x40000000,
       :S_ATTR_STRIP_STATIC_SYMS => 0x20000000,
@@ -54,6 +60,13 @@ module MachO
       :S_ATTR_SOME_INSTRUCTIONS => 0x00000400,
       :S_ATTR_EXT_RELOC => 0x00000200,
       :S_ATTR_LOC_RELOC => 0x00000100,
+    }.freeze
+
+    # association of section flag symbols to values
+    # @api private
+    SECTION_FLAGS = {
+      **SECTION_TYPES,
+      **SECTION_ATTRIBUTES,
     }.freeze
 
     # association of section name symbols to names
@@ -147,6 +160,33 @@ module MachO
         size.zero?
       end
 
+      # @return [Integer] the raw numeric type of this section
+      def type
+        flags & SECTION_TYPE_MASK
+      end
+
+      # @example
+      #  puts "this section is regular" if sect.type?(:S_REGULAR)
+      # @param type_sym [Symbol] a section type symbol
+      # @return [Boolean] whether this section is of the given type
+      def type?(type_sym)
+        type == SECTION_TYPES[type_sym]
+      end
+
+      # @return [Integer] the raw numeric attributes of this section
+      def attributes
+        flags & SECTION_ATTRIBUTES_MASK
+      end
+
+      # @example
+      #  puts "pure instructions" if sect.attribute?(:S_ATTR_PURE_INSTRUCTIONS)
+      # @param attr_sym [Symbol] a section attribute symbol
+      # @return [Boolean] whether this section is of the given type
+      def attribute?(attr_sym)
+        !!(attributes & SECTION_ATTRIBUTES[attr_sym])
+      end
+
+      # @deprecated Use {#type?} or {#attribute?} instead.
       # @example
       #  puts "this section is regular" if sect.flag?(:S_REGULAR)
       # @param flag [Symbol] a section flag symbol

--- a/lib/macho/sections.rb
+++ b/lib/macho/sections.rb
@@ -10,10 +10,10 @@ module MachO
     SECTION_ATTRIBUTES_MASK = 0xffffff00
 
     # user settable attributes mask
-    SECTION_ATTRIBUTES_USR = 0xff000000
+    SECTION_ATTRIBUTES_USR_MASK = 0xff000000
 
     # system settable attributes mask
-    SECTION_ATTRIBUTES_SYS = 0x00ffff00
+    SECTION_ATTRIBUTES_SYS_MASK = 0x00ffff00
 
     # maximum specifiable section alignment, as a power of 2
     # @note see `MAXSECTALIGN` macro in `cctools/misc/lipo.c`

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -121,6 +121,9 @@ class MachOFileTest < Minitest::Test
         assert_kind_of Integer, seg.nsects
         assert_kind_of Integer, seg.flags
         refute seg.flag?(:THIS_IS_A_MADE_UP_FLAG)
+        if seg.flags != 0
+          assert MachO::LoadCommands::SEGMENT_FLAGS.keys.one? { |sf| seg.flag?(sf) }
+        end
 
         sections = seg.sections
 

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -141,6 +141,11 @@ class MachOFileTest < Minitest::Test
           assert_kind_of Integer, sect.nreloc
           assert_kind_of Integer, sect.flags
           refute sect.flag?(:THIS_IS_A_MADE_UP_FLAG)
+          assert_kind_of Integer, sect.type
+          assert MachO::Sections::SECTION_TYPES.values.include?(sect.type)
+          assert MachO::Sections::SECTION_TYPES.keys.one? { |st| sect.type?(st) }
+          assert_kind_of Integer, sect.attributes
+          assert MachO::Sections::SECTION_ATTRIBUTES.keys.any? { |sa| sect.attribute?(sa) }
           assert_kind_of Integer, sect.reserved1
           assert_kind_of Integer, sect.reserved2
           assert_kind_of Integer, sect.reserved3 if sect.is_a? MachO::Sections::Section64


### PR DESCRIPTION
These two predicates replace the `Section#flag?` predicate, which
has unintuitive behavior and is now deprecated.

Closes #423.