### PR TITLE
Support for MH_FILESET

### DIFF
--- a/lib/macho/headers.rb
+++ b/lib/macho/headers.rb
@@ -445,7 +445,8 @@ module MachO
     # @api private
     MH_KEXT_BUNDLE = 0xb
 
-    # a set of Mach-Os, running in the same userspace, sharing a linkedit
+    # a set of Mach-Os, running in the same userspace, sharing a linkedit.  The kext collection files are an example
+    # of this object type
     # @api private
     MH_FILESET = 0xc
 
@@ -463,6 +464,7 @@ module MachO
       MH_DYLIB_STUB => :dylib_stub,
       MH_DSYM => :dsym,
       MH_KEXT_BUNDLE => :kext_bundle,
+      MH_FILESET => :fileset,
     }.freeze
 
     # association of mach header flag symbols to values

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -1820,6 +1820,24 @@ module MachO
       # @see MachOStructure::SIZEOF
       # @api private
       SIZEOF = 20
+
+      def initialize(view, cmd, cmdsize, vmaddr, fileoff, entry_id, reserved)
+        super(view, cmd, cmdsize)
+        @vmaddr = vmaddr
+        @fileoff = fileoff
+        @entry_id = entry_id
+        @reserved = reserved
+      end
+
+      # @return [Hash] a hash representation of this {FilesetEntryCommand}
+      def to_h
+        {
+          "vmaddr" => vmaddr,
+          "fileoff" => fileoff,
+          "entry_id" => entry_id,
+          "reserved" => reserved,
+        }.merge super
+      end
     end
   end
 end

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -1825,7 +1825,7 @@ module MachO
         super(view, cmd, cmdsize)
         @vmaddr = vmaddr
         @fileoff = fileoff
-        @entry_id = entry_id
+        @entry_id = LCStr.new(self, entry_id)
         @reserved = reserved
       end
 

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -160,8 +160,8 @@ module MachO
     #  the instance fields
     # @raise [OffsetInsertionError] if the offset is not in the load command region
     # @raise [HeaderPadError] if the new command exceeds the header pad buffer
-    # @note Calling this method with an arbitrary offset in the load command
-    #  region **will leave the object in an inconsistent state**.
+    # @note Calling this method with an arbitrary offset in the load command region
+    # **will leave the object in an inconsistent state**.
     def insert_command(offset, lc, options = {})
       context = LoadCommands::LoadCommand::SerializationContext.context_for(self)
       cmd_raw = lc.serialize(context)

--- a/test/test_kc.rb
+++ b/test/test_kc.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "helpers"
+
+BOOT_KERNEL_COLLECTION = '/System/Library/KernelCollections/BootKernelExtensions.kc'
+
+if File.exist? BOOT_KERNEL_COLLECTION
+class KextCollectionTests < Minitest::Test
+  include Helpers
+
+  def test_load_kc
+    MachO.open BOOT_KERNEL_COLLECTION
+  end
+end
+end


### PR DESCRIPTION
The macOS 11/12 system uses a new scheme of KextCollections (BootKernelCollection, AuxiliaryKernelCollection, etc).  These are created as MH_FILESET objects.  This PR completes support for MH_FILESET and its related load commands