### PR TITLE
Fix for using `macho` in Pry/IRB

### DIFF
--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -1839,6 +1839,11 @@ module MachO
           "reserved" => reserved,
         }.merge super
       end
+
+      # @return [SegmentCommand64, nil] the matching segment command or nil if nothing matches
+      def segment
+        view.macho_file.command(:LC_SEGMENT_64).select { |cmd| cmd.fileoff == fileoff }.first
+      end
     end
   end
 end

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -592,7 +592,7 @@ module MachO
           LoadCommands::LoadCommand
         end
 
-        view = MachOView.new(@raw_data, endianness, offset)
+        view = MachOView.new(self, @raw_data, endianness, offset)
         command = klass.new_from_bin(view)
 
         load_commands << command

--- a/lib/macho/view.rb
+++ b/lib/macho/view.rb
@@ -29,5 +29,9 @@ module MachO
         "offset" => offset,
       }
     end
+
+    def inspect
+      "#<#{self.class}:0x#{self.__id__.to_s(16)} @endianness=#{@endianness.inspect}, @offset=#{@offset.inspect}, length=#{@raw_data.length}>"
+    end
   end
 end

--- a/lib/macho/view.rb
+++ b/lib/macho/view.rb
@@ -3,6 +3,9 @@
 module MachO
   # A representation of some unspecified Mach-O data.
   class MachOView
+    # @return [MachOFile] that this view belongs to
+    attr_reader :macho_file
+
     # @return [String] the raw Mach-O data
     attr_reader :raw_data
 
@@ -13,10 +16,12 @@ module MachO
     attr_reader :offset
 
     # Creates a new MachOView.
+    # @param macho_file [MachOFile] the file this view slice is from
     # @param raw_data [String] the raw Mach-O data
     # @param endianness [Symbol] the endianness of the data
     # @param offset [Integer] the offset of the relevant data
-    def initialize(raw_data, endianness, offset)
+    def initialize(macho_file, raw_data, endianness, offset)
+      @macho_file = macho_file
       @raw_data = raw_data
       @endianness = endianness
       @offset = offset
@@ -31,7 +36,7 @@ module MachO
     end
 
     def inspect
-      "#<#{self.class}:0x#{self.__id__.to_s(16)} @endianness=#{@endianness.inspect}, @offset=#{@offset.inspect}, length=#{@raw_data.length}>"
+      "#<#{self.class}:0x#{(object_id << 1).to_s(16)} @endianness=#{@endianness.inspect}, @offset=#{@offset.inspect}, length=#{@raw_data.length}>"
     end
   end
 end

--- a/test/test_create_load_commands.rb
+++ b/test/test_create_load_commands.rb
@@ -31,6 +31,7 @@ class MachOLoadCommandCreationTest < Minitest::Test
       assert_equal 0, lc.timestamp
       assert_equal 0, lc.current_version
       assert_equal 0, lc.compatibility_version
+      assert_instance_of String, lc.view.inspect
     end
   end
 

--- a/test/test_fat.rb
+++ b/test/test_fat.rb
@@ -497,10 +497,10 @@ class FatFileTest < Minitest::Test
     file.change_install_name("/usr/lib/libz.1.dylib", "foo", :strict => false)
 
     # ...but not all slices will have the modified dylib
-    refute (file.machos.all? { |m| m.linked_dylibs.include?("foo") })
+    refute(file.machos.all? { |m| m.linked_dylibs.include?("foo") })
 
     # ...but at least one will
-    assert (file.machos.any? { |m| m.linked_dylibs.include?("foo") })
+    assert(file.machos.any? { |m| m.linked_dylibs.include?("foo") })
   end
 
   def test_dylib_load_commands
@@ -515,6 +515,16 @@ class FatFileTest < Minitest::Test
         assert_kind_of MachO::LoadCommands::DylibCommand, lc
       end
     end
+  end
+
+  def test_fail_loading_thin
+    filename = fixture('x86_64', 'libhello.dylib')
+
+    ex = assert_raises(MachO::MachOBinaryError) do
+      MachO::FatFile.new_from_bin File.read(filename)
+    end
+
+    assert_match(/must be/, ex.inspect)
   end
 
   def test_to_h

--- a/test/test_kc.rb
+++ b/test/test_kc.rb
@@ -2,14 +2,14 @@
 
 require_relative "helpers"
 
-BOOT_KERNEL_COLLECTION = '/System/Library/KernelCollections/BootKernelExtensions.kc'
+BOOT_KERNEL_COLLECTION = "/System/Library/KernelCollections/BootKernelExtensions.kc"
 
 if File.exist? BOOT_KERNEL_COLLECTION
-class KextCollectionTests < Minitest::Test
-  include Helpers
+  class KextCollectionTests < Minitest::Test
+    include Helpers
 
-  def test_load_kc
-    MachO.open BOOT_KERNEL_COLLECTION
+    def test_load_kc
+      MachO.open BOOT_KERNEL_COLLECTION
+    end
   end
-end
 end

--- a/test/test_kc.rb
+++ b/test/test_kc.rb
@@ -11,5 +11,12 @@ if File.exist? BOOT_KERNEL_COLLECTION
     def test_load_kc
       MachO.open BOOT_KERNEL_COLLECTION
     end
+
+    def test_navigate_fileset_command
+      macho = MachO.open BOOT_KERNEL_COLLECTION
+
+      fileset_entry = macho.command(:LC_FILESET_ENTRY).first
+      assert(fileset_entry.segment)
+    end
   end
 end

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -121,9 +121,7 @@ class MachOFileTest < Minitest::Test
         assert_kind_of Integer, seg.nsects
         assert_kind_of Integer, seg.flags
         refute seg.flag?(:THIS_IS_A_MADE_UP_FLAG)
-        if seg.flags != 0
-          assert MachO::LoadCommands::SEGMENT_FLAGS.keys.one? { |sf| seg.flag?(sf) }
-        end
+        assert MachO::LoadCommands::SEGMENT_FLAGS.keys.one? { |sf| seg.flag?(sf) } if seg.flags != 0
 
         sections = seg.sections
 
@@ -587,6 +585,16 @@ class MachOFileTest < Minitest::Test
     assert_raises MachO::RpathUnknownError do
       file.delete_rpath("/this/rpath/doesn't/exist")
     end
+  end
+
+  def test_fail_loading_fat
+    filename = fixture(['i386', 'x86_64'], 'libhello.dylib')
+
+    ex = assert_raises(MachO::FatBinaryError) do
+      MachO::MachOFile.new_from_bin File.read(filename)
+    end
+
+    assert_match(/must be/, ex.inspect)
   end
 
   def test_to_h


### PR DESCRIPTION
Using 'macho' in Pry/IRB was slow due to the editor printing the entire contents of @raw_data, this makes the inspect element print only the length of the view.