### PR TITLE
Delete last rpath when requested

### DIFF
--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -428,7 +428,7 @@ module MachO
     def delete_rpath(path, options = {})
       uniq = options.fetch(:uniq, false)
       last = options.fetch(:last, false)
-      raise ArgumentError, "Cannot set both :uniq and :last to true!" if uniq && last
+      raise ArgumentError, "Cannot set both :uniq and :last to true" if uniq && last
 
       search_method = uniq || last ? :select : :find
       rpath_cmds = command(:LC_RPATH).public_send(search_method) { |r| r.path.to_s == path }

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -418,15 +418,24 @@ module MachO
     # @param options [Hash]
     # @option options [Boolean] :uniq (false) if true, also delete
     #  duplicates of the requested path. If false, delete the first
-    #  instance (by offset) of the requested path.
+    #  instance (by offset) of the requested path, unless :last is true.
+    #  Incompatible with :last.
+    # @option options [Boolean] :last (false) if true, delete the last
+    # instance (by offset) of the requested path. Incompatible with :uniq.
     # @return void
     # @raise [RpathUnknownError] if no such runtime path exists
+    # @raise [ArgumentError] if both :uniq and :last are true
     def delete_rpath(path, options = {})
       uniq = options.fetch(:uniq, false)
-      search_method = uniq ? :select : :find
+      last = options.fetch(:last, false)
+      raise ArgumentError, "Cannot set both :uniq and :last to true!" if uniq && last
+
+      search_method = uniq || last ? :select : :find
+      rpath_cmds = command(:LC_RPATH).public_send(search_method) { |r| r.path.to_s == path }
+      rpath_cmds = rpath_cmds.last if last
 
       # Cast rpath_cmds into an Array so we can handle the uniq and non-uniq cases the same way
-      rpath_cmds = Array(command(:LC_RPATH).method(search_method).call { |r| r.path.to_s == path })
+      rpath_cmds = Array(rpath_cmds)
       raise RpathUnknownError, path if rpath_cmds.empty?
 
       # delete the commands in reverse order, offset descending.


### PR DESCRIPTION
Deleting the first rpath is a good default because it mirrors the
behaviour of `install_name_tool`. However, it's not useful behaviour
when deleting duplicate rpaths, because it changes the order in which
the runtime paths are searched.

We delete duplicate rpaths in `brew`, so being able to delete the last
instance of the requested rpath instead of the first one would be
useful.
