### PR TITLE
workflows: pin setup-ruby action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@main
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@70da3bbf44ac06db1b0547ce2acc9380a5270d1e # v1.175.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true


### PR DESCRIPTION
Picked from #596 to fix the 3p PR perm issue.

Closes #596.