### PR TITLE
Migrate from deprecated Codecov Ruby gem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Git repository
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@70da3bbf44ac06db1b0547ce2acc9380a5270d1e # v1.175.0
@@ -27,3 +27,10 @@ jobs:
 
     - name: Run RuboCop
       run: bundle exec rubocop -D lib/
+
+    - name: Upload coverage results
+      uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4.4.1
+      with:
+        files: coverage/coverage.xml
+        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@ source "https://rubygems.org"
 
 group :test, :development do
   gem "benchmark-ips"
-  gem "codecov", :require => false
   gem "minitest"
   gem "rake"
   gem "rubocop"
+  gem "simplecov-cobertura", :require => false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,6 @@ GEM
     ast (2.4.2)
     benchmark-ips (2.13.0)
     childprocess (5.0.0)
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
     docile (1.4.0)
     iniparse (1.5.0)
     json (2.7.1)
@@ -40,6 +38,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     unicode-display_width (2.5.0)
@@ -49,11 +50,11 @@ PLATFORMS
 
 DEPENDENCIES
   benchmark-ips
-  codecov
   minitest
   overcommit
   rake
   rubocop
+  simplecov-cobertura
 
 BUNDLED WITH
    2.3.5

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-# if we're running the tests on the CI, generate a codecov coverage report
+# if we're running the tests on the CI, generate a coverage report
 if ENV["CI"]
   require "simplecov"
+  require "simplecov-cobertura"
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
   SimpleCov.start
-
-  require "codecov"
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
 require "digest/sha1"


### PR DESCRIPTION
Use a general Cobertura gem and then feed that into Codecov's GitHub Action.

This allow will allow Simplecov 0.22 to be used (not updated in this PR).

Fixes #601.