### PR TITLE
workflows/tests: fix Ruby 3.0 test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "macos-latest"]
-        ruby: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Git repository


### PR DESCRIPTION
`3.0` is interpreted as a number (`3`) so was actually testing the latest Ruby 3.x.