### PR TITLE
macho: 4.1.0

### DIFF
--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -16,7 +16,7 @@ require_relative "macho/tools"
 # The primary namespace for ruby-macho.
 module MachO
   # release version
-  VERSION = "4.0.1"
+  VERSION = "4.1.0"
 
   # Opens the given filename as a MachOFile or FatFile, depending on its magic.
   # @param filename [String] the file being opened


### PR DESCRIPTION
Bumps the version; will tag and release once this is on `master`.