### PR TITLE
workflows: add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release Gem to rubygems.org
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    environment: rubygems.org
+
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@0cde4689ba33c09f1b890c1725572ad96751a3fc # v1.178.0
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@612653d273a73bdae1df8453e090060bb4db5f31 # v1

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
+
+require "bundler/gem_tasks"
 require "rake/testtask"
 require_relative "test/bench"
 


### PR DESCRIPTION
This moves ruby-macho from a "William pushes it from his desktop" release process to a CI-managed one, with Trusted Publishing as the authentication mechanism.

Anybody with the ability to create releases on this repo can now release from it. The workflow itself is currently tied to the `rubygems.org` deployment environment, to which we could add signoff restrictions as well.

NB: I've already configured the Trusted Publisher for ruby-macho on RubyGems:

![](https://thing-in-itself.net/u/UX7iJAFQ7to.png)

Closes #273 