### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/ruby-macho.gemspec
+++ b/ruby-macho.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/Homebrew/ruby-macho"
   s.license = "MIT"
   s.metadata["rubygems_mfa_required"] = "true"
+  s.metadata["funding_uri"] = "https://github.com/sponsors/Homebrew"
 end


### PR DESCRIPTION
I noticed that the project already has a funding link (https://github.com/sponsors/Homebrew). This PR adds the `funding_uri` to the gemspec to help increase visibility using the `bundle fund` command in Bundler.