### PR TITLE
README: Update information about architecture support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ puts lc_vers.version_string # => "10.10.0"
 
 ### What works?
 
-* Reading data from x86/x86_64/arm64/PPC Mach-O files (other architectures may work too, but are untested)
+* Reading data from x86/x86_64/arm64/PPC Mach-O files (other architectures are unsupported, but may work)
 * Changing the IDs of Mach-O and Fat dylibs
 * Changing install names in Mach-O and Fat files
 * Adding, deleting, and modifying rpaths.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ puts lc_vers.version_string # => "10.10.0"
 
 ### What works?
 
-* Reading data from x86/x86_64/PPC Mach-O files
+* Reading data from x86/x86_64/arm64/PPC Mach-O files (other architectures may work too, but are untested)
 * Changing the IDs of Mach-O and Fat dylibs
 * Changing install names in Mach-O and Fat files
 * Adding, deleting, and modifying rpaths.


### PR DESCRIPTION
The arm64 code is used in production, so call it out explicitly.

The code also includes at least partial support for arm, arm64_32, m68k, and m88k. They aren't tested, and I'm not aware of production use of these platforms with ruby-macho, so don't mention them by name as working.

Closes: #971