### PR TITLE
Validate Mach-O headers before full reads

### DIFF
--- a/lib/macho/fat_file.rb
+++ b/lib/macho/fat_file.rb
@@ -96,7 +96,12 @@ module MachO
 
       @filename = filename
       @options = opts
-      @raw_data = File.binread(@filename)
+      File.open(@filename, "rb") do |file|
+        @raw_data = file.read(Headers::FatHeader.bytesize)
+        @raw_data ||= ""
+        populate_fat_header
+        @raw_data << file.read.to_s
+      end
       populate_fields
     end
 

--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -60,7 +60,12 @@ module MachO
 
       @filename = filename
       @options = opts
-      @raw_data = File.binread(@filename)
+      File.open(@filename, "rb") do |file|
+        @raw_data = file.read(Headers::MachHeader.bytesize)
+        @raw_data ||= ""
+        populate_mach_header if !opts.fetch(:decompress, false) || !Utils.compressed_magic?(@raw_data.unpack1("N"))
+        @raw_data << file.read.to_s
+      end
       populate_fields
     end
 

--- a/test/test_fat.rb
+++ b/test/test_fat.rb
@@ -36,6 +36,20 @@ class FatFileTest < Minitest::Test
     end
   end
 
+  def test_invalid_header_is_rejected_before_full_read
+    tempfile_with_data("invalid_header", [MachO::Headers::FAT_MAGIC, 31].pack("N2") + ("x" * 1024)) do |invalid_header|
+      assert_raises MachO::JavaClassFileError do
+        Class.new(MachO::FatFile) do
+          def populate_fat_header
+            raise "read entire file" if serialize.bytesize > MachO::Headers::FatHeader.bytesize
+
+            super
+          end
+        end.new(invalid_header.path)
+      end
+    end
+  end
+
   def test_zero_arch_file
     assert_raises MachO::ZeroArchitectureError do
       MachO::FatFile.new("test/bin/llvm/macho-invalid-fat-header")

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -27,6 +27,20 @@ class MachOFileTest < Minitest::Test
     end
   end
 
+  def test_invalid_header_is_rejected_before_full_read
+    tempfile_with_data("invalid_header", [MachO::Headers::MH_MAGIC, 0, 0, MachO::Headers::MH_EXECUTE, 0, 0, 0].pack("N7") + ("x" * 1024)) do |invalid_header|
+      assert_raises MachO::CPUTypeError do
+        Class.new(MachO::MachOFile) do
+          def populate_mach_header
+            raise "read entire file" if serialize.bytesize > MachO::Headers::MachHeader.bytesize
+
+            super
+          end
+        end.new(invalid_header.path)
+      end
+    end
+  end
+
   def test_load_commands
     filenames = SINGLE_ARCHES.map { |a| fixture(a, "hello.bin") }
 


### PR DESCRIPTION
- Avoid loading large invalid files before `MachOFile` and `FatFile` can reject malformed headers.
- Keep successful parsing on one handle so serialisation and mutation continue to use complete file data.
- Preserve compressed Mach-O handling when decompression needs the full payload.

Fixes https://github.com/Homebrew/ruby-macho/issues/23