### PR TITLE
Drop support for Ruby 3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "macos-latest"]
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set up Git repository

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   NewCops: enable
 
 Style/StringLiterals:

--- a/ruby-macho.gemspec
+++ b/ruby-macho.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors = ["William Woodruff"]
   s.email = "william@yossarian.net"
   s.files = Dir["LICENSE", "README.md", ".yardopts", "lib/**/*"]
-  s.required_ruby_version = ">= 3.2"
+  s.required_ruby_version = ">= 3.3"
   s.homepage = "https://github.com/Homebrew/ruby-macho"
   s.license = "MIT"
   s.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
Ruby 3.2 is now EOL. Bumps the minimum to 3.3 across the gemspec, RuboCop target, and CI matrix.