### PR TITLE
Validate segment nsects against cmdsize and file bounds

### DIFF
--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -472,6 +472,9 @@ module MachO
         offset = view.offset + self.class.bytesize
         length = nsects * klass.bytesize
 
+        available = view.raw_data.bytesize - offset
+        raise LoadCommandSizeError, cmdsize if length > available || self.class.bytesize + length > cmdsize
+
         bins = view.raw_data[offset, length]
         bins.unpack("a#{klass.bytesize}" * nsects).map do |bin|
           klass.new_from_bin(view.endianness, bin)

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -65,6 +65,14 @@ class MachOFileTest < Minitest::Test
     end
   end
 
+  def test_segment_with_too_many_sections
+    assert_segment_sections_exceed_cmdsize(:i386, :LC_SEGMENT)
+  end
+
+  def test_segment_64_with_too_many_sections
+    assert_segment_sections_exceed_cmdsize(:x86_64, :LC_SEGMENT_64)
+  end
+
   def test_minimal_macho
     file = MachO::MachOFile.new(fixture(:yaml2obj, "minimal.macho"))
 
@@ -801,6 +809,28 @@ class MachOFileTest < Minitest::Test
       # the structure should contain a format and a bytesize
       assert_kind_of String, lc_hsh["structure"]["format"]
       assert_kind_of Integer, lc_hsh["structure"]["bytesize"]
+    end
+  end
+
+  private
+
+  def assert_segment_sections_exceed_cmdsize(arch, command_type)
+    bin = File.binread(fixture(arch, "hello.bin"))
+    file = MachO::MachOFile.new_from_bin(bin)
+    segment = file[command_type].first
+    section_class = if segment.is_a?(MachO::LoadCommands::SegmentCommand64)
+      MachO::Sections::Section64
+    else
+      MachO::Sections::Section
+    end
+    nsects = ((segment.cmdsize - segment.class.bytesize) / section_class.bytesize) + 1
+    nsects_offset = segment.view.offset + segment.class.bytesize - 8
+    bin[nsects_offset, 4] = [nsects].pack(file.endianness == :little ? "L<" : "L>")
+
+    segment = MachO::MachOFile.new_from_bin(bin)[command_type].first
+
+    assert_raises MachO::LoadCommandSizeError do
+      segment.sections
     end
   end
 end


### PR DESCRIPTION
- Check length against available file data and that section table fits cmdsize
- Raise LoadCommandSizeError on invalid nsects values

A quick PoC script (tested on Linux, haven't checked if `rss_mb` works on macOS) which loads a modified variant of the test fixture (manipulating `nsects` to be invalidly large) and can cause a large memory allocation:
```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true
# PoC: reach bad nsects via SegmentCommand#to_h (public caller).
require "macho"

def rss_mb
  File.read("/proc/self/status")[/VmRSS:\s+(\d+) kB/, 1].to_i / 1024
rescue
  0
end

path = "./test/bin/x86_64/hello.bin"
raw = File.binread(path)
f = MachO::MachOFile.new(path)
seg = f.segments.find { |s| s.segname == "__TEXT" }
puts "valid file contains: nsects=#{seg.nsects} sections=#{seg.to_h["sections"].size}"

[1000, 1_000_000].each do |n|
  bad = raw.dup
  bad[seg.view.offset + 64, 4] = [n].pack("L<")
  print "\nnsects=#{n}: "
  t0 = Time.now
  before = rss_mb
  begin
    MachO::MachOFile.new_from_bin(bad).segments
      .find { |s| s.segname == "__TEXT" }.to_h
  rescue MachO::MachOError => e
    puts "#{e.class} caught"
  end
  puts "rss #{before} MiB -> #{rss_mb} MiB"
end
```