### PR TITLE
Prep ruby-macho 7.0.0

### DIFF
--- a/lib/macho.rb
+++ b/lib/macho.rb
@@ -15,7 +15,7 @@ require_relative "macho/tools"
 # The primary namespace for ruby-macho.
 module MachO
   # release version
-  VERSION = "6.0.0"
+  VERSION = "7.0.0"
 
   # Opens the given filename as a MachOFile or FatFile, depending on its magic.
   # @param filename [String] the file being opened


### PR DESCRIPTION
Prepare the 7.0.0 release. Incrementing the major version since we dropped Ruby 3.2 since the last release.