### PR TITLE
Modernize repository checks and add CONTRIBUTING.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     env:
       BUNDLE_FROZEN: "true"
@@ -32,6 +33,14 @@ jobs:
           ruby-version: ruby
 
       - run: bundle install --jobs=4
+
+      - name: Verify release metadata
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: bundle exec rake verify_release_tag verify_unpublished_version
+
+      - name: Run release checks
+        run: bundle exec rake
 
       # Release
       - uses: rubygems/release-gem@7f9650160c1a4e7989fdc9855807bdbd421d8b6b # v1.4.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   tests:
+    timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         platform: ["ubuntu-latest", "macos-latest"]
         ruby: ["3.3", "3.4", "4.0"]
@@ -28,13 +30,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - name: Run tests
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run repository checks
         run: bundle exec rake
-
-      - name: Run RuboCop
-        run: bundle exec rubocop -D lib/
 
       - name: Upload coverage results
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /doc/
 
 # Gems for redistribution.
+/pkg/
 /ruby-macho-*.gem
 
 # Testing.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,11 @@
 AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
   TargetRubyVersion: 3.3
   NewCops: enable
+  SuggestExtensions:
+    rubocop-minitest: false
+    rubocop-rake: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -66,4 +71,3 @@ Naming/VariableNumber:
 Metrics/BlockLength:
   Exclude:
     - 'test/**'
-

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,7 @@
---no-private --markup-provider=redcarpet --markup=markdown - README.md LICENSE
+--no-private
+--markup markdown
+-
+README.md
+machostructure-dsl-docs.md
+CONTRIBUTING.md
+LICENSE

--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 brew "ruby"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to ruby-macho
+
+Thank you for helping improve `ruby-macho`.
+
+## Set up the repository
+
+Install Ruby 3.3 or newer and Bundler, then install the locked dependencies:
+
+```console
+bundle install
+```
+
+Run the same repository-owned checks used by CI:
+
+```console
+bundle exec rake
+```
+
+That command runs RuboCop, the complete Minitest suite, YARD documentation
+checks, and a build-and-smoke test of the packaged gem. CI also enforces the
+current minimum line and branch coverage percentages.
+
+Useful focused commands are:
+
+```console
+bundle exec rake test
+bundle exec ruby -Ilib -Itest test/test_macho.rb
+bundle exec rubocop
+bundle exec rake doc
+bundle exec rake package_smoke
+bundle exec rake bench
+```
+
+The benchmark task requires macOS command-line tools. The library and test
+suite otherwise run on both macOS and Linux, as reflected in the CI matrix.
+
+You can optionally install the repository's pre-commit checks with:
+
+```console
+bundle exec overcommit --install
+```
+
+## Submit a change
+
+- Add a focused regression test for behavior changes and bug fixes.
+- Keep public behavior and limitations documented in `README.md` and YARD
+  comments.
+- Keep commits focused and include a `Signed-off-by` trailer. `git commit -s`
+  adds it automatically.
+- Run `bundle exec rake` before opening a pull request.
+
+## Test fixtures
+
+Mach-O fixtures live under `test/bin`. Prefer a small, source-generated
+reproducer over copying a production binary. Sources and generation recipes
+live under `test/src` and `test/bin/yaml2obj`.
+
+Any new or replaced binary fixture must include:
+
+- the smallest practical source or deterministic generation recipe;
+- the upstream source and version, when applicable;
+- a SHA-256 digest for externally built artifacts;
+- the reason the fixture is necessary and the test that exercises it; and
+- its license and attribution requirements.
+
+LLVM-derived malformed fixtures retain their license in
+`test/bin/llvm/LICENSE.txt`. Update the README attribution and keep applicable
+license material adjacent to any new third-party fixture.
+
+## Reporting problems
+
+Use [GitHub Issues](https://github.com/Homebrew/ruby-macho/issues) for ordinary
+bugs. Report suspected vulnerabilities privately through
+[GitHub's security advisory form](https://github.com/Homebrew/ruby-macho/security/advisories/new)
+and follow [Homebrew's security policy](https://github.com/Homebrew/.github/security/policy).

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,14 @@ source "https://rubygems.org"
 
 group :test, :development do
   gem "benchmark-ips"
+  # Keep YARD 0.9's legacy lexer on its IRB notifier path instead of its fallback shim on Ruby 4.
+  gem "irb"
   gem "minitest"
   gem "rake"
   gem "rubocop"
+  gem "simplecov", ">= 1.1", "< 2", :require => false
   gem "simplecov-cobertura", :require => false
+  gem "yard", "~> 0.9"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,14 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     drb (2.2.3)
+    erb (6.0.7)
     iniparse (1.5.0)
+    io-console (0.9.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.21.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
@@ -22,11 +29,25 @@ GEM
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.9.0)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.4.2)
+    rbs (4.2.0)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
     regexp_parser (2.12.0)
+    reline (0.7.0)
+      io-console (~> 0.5)
     rexml (3.4.4)
     rubocop (1.90.0)
       json (>= 2.3)
@@ -47,27 +68,35 @@ GEM
     simplecov-cobertura (4.0.0)
       rexml
       simplecov (~> 1.0)
+    tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    yard (0.9.45)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   benchmark-ips
+  irb
   minitest
   overcommit
   rake
   rubocop
+  simplecov (>= 1.1, < 2)
   simplecov-cobertura
+  yard (~> 0.9)
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   benchmark-ips (2.15.1) sha256=07a1a9f3c6105ecaf68c174fc3fbcddd71a0e9ada6236ae03093a0dcfd812d59
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
   iniparse (1.5.0) sha256=36a165e98d8a250b7631c4a7f9afba32af78f089970cd6446a39771189c761f1
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
@@ -76,19 +105,26 @@ CHECKSUMS
   overcommit (0.72.0) sha256=1cb8e39639e2f203ced5a303c2ac1e24ce49824ead52fa3204f954f936a63a3e
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.2.0) sha256=51f7b886dcc05bc09e10b901daa6a81829f6adc03101d6ca9ea4aac6103e0674
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rubocop (1.90.0) sha256=9eb4c065b5c5154e4ef554c547972f3905a9eb6b53e657e580b6796b54bf8242
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   simplecov (1.1.1) sha256=25825ef13f0b2e74694d769817dad6ab8e90131dabdaa666e522fea105521e78
   simplecov-cobertura (4.0.0) sha256=e4fb3159b1ecea545b44f5452a8611305323e78ad23eae8aed35924d072e01ea
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  yard (0.9.45) sha256=52e211493f7cb8a3ebf7e104a25a1e73937a3103092545d34cb88fafebb3dc51
 
 BUNDLED WITH
   4.0.16

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ruby-macho
 ================
 
-[![Gem Version](https://badge.fury.io/rb/ruby-macho.svg)](http://badge.fury.io/rb/ruby-macho)
+[![Gem Version](https://badge.fury.io/rb/ruby-macho.svg)](https://badge.fury.io/rb/ruby-macho)
 [![CI](https://github.com/Homebrew/ruby-macho/actions/workflows/tests.yml/badge.svg)](https://github.com/Homebrew/ruby-macho/actions/workflows/tests.yml)
 [![Coverage Status](https://codecov.io/gh/Homebrew/ruby-macho/branch/main/graph/badge.svg)](https://codecov.io/gh/Homebrew/ruby-macho)
 
@@ -23,7 +23,7 @@ $ gem install ruby-macho
 
 ### Documentation
 
-Full documentation is available on [RubyDoc](http://www.rubydoc.info/gems/ruby-macho/).
+Full documentation is available on [RubyDoc](https://www.rubydoc.info/gems/ruby-macho/).
 
 A quick example of what ruby-macho can do:
 
@@ -65,21 +65,10 @@ MachO.codesign!("/path/to/my/binary")
 * Adding, deleting, and modifying rpaths.
 * Parsing embedded code signatures and applying ad-hoc signatures in pure Ruby.
 
-### What needs to be done?
+### Contributing
 
-* Unit and performance testing.
-
-### Contributing, setting up `overcommit` and the linters
-
-In order to keep the repo, docs and data tidy, we use a tool called [`overcommit`](https://github.com/sds/overcommit)
-to connect up the git hooks to a set of quality checks.  The fastest way to get setup is to run the following to make
-sure you have all the tools:
-
-```shell
-gem install overcommit bundler
-bundle install
-overcommit --install
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for repository setup, checks, fixture
+guidance, and the contribution process.
 
 ### Attribution
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,16 +4,72 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "bundler/gem_tasks"
 require "rake/testtask"
-require_relative "test/bench"
+require "rubocop/rake_task"
+require "rubygems/package"
+require "rubygems/spec_fetcher"
+require "tmpdir"
+require "yard"
 
-Rake::TestTask.new do |t|
+require_relative "lib/macho"
+
+task :default => :check
+task :check => %i[rubocop test doc package_smoke]
+
+desc "Verify that RELEASE_TAG matches the gem version"
+task :verify_release_tag do
+  release_tag = ENV.fetch("RELEASE_TAG") { abort "RELEASE_TAG is required" }
+  expected_tag = "v#{MachO::VERSION}"
+  abort "release tag #{release_tag} does not match #{expected_tag}" unless release_tag == expected_tag
+end
+
+desc "Verify that the gem version has not already been published"
+task :verify_unpublished_version do
+  dependency = Gem::Dependency.new("ruby-macho", "= #{MachO::VERSION}")
+  matching_specs, errors = Gem::SpecFetcher.fetcher.spec_for_dependency(dependency)
+  abort "could not verify published ruby-macho versions: #{errors.map(&:message).join("; ")}" unless errors.empty?
+  abort "ruby-macho #{MachO::VERSION} is already published" unless matching_specs.empty?
+end
+
+desc "Build and smoke-test the packaged gem"
+task :package_smoke => :build do
+  gem_path = File.expand_path("pkg/ruby-macho-#{MachO::VERSION}.gem", __dir__)
+
+  Dir.mktmpdir("ruby-macho-package") do |package_dir|
+    Gem::Package.new(gem_path).extract_files(package_dir)
+    package_lib = File.join(package_dir, "lib")
+    env = {
+      "BUNDLE_GEMFILE" => nil,
+      "PACKAGE_LIB" => package_lib,
+      "RUBYLIB" => package_lib,
+      "RUBYOPT" => nil,
+    }
+    load_check = <<~'RUBY'
+      require "macho"
+      loaded_path = $LOADED_FEATURES.find { |path| path.end_with?("/macho.rb") }
+      abort "macho was not loaded" unless loaded_path
+
+      package_prefix = "#{File.realpath(ENV.fetch("PACKAGE_LIB"))}#{File::SEPARATOR}"
+      abort "macho loaded from #{loaded_path}, not the packaged gem" unless File.realpath(loaded_path).start_with?(package_prefix)
+    RUBY
+
+    abort "packaged gem failed to load" unless system(env, Gem.ruby, "--disable-gems", "-e", load_check)
+  end
+end
+
+RuboCop::RakeTask.new(:rubocop)
+
+Rake::TestTask.new(:test) do |t|
   t.libs << "test"
 end
 
-desc "Run tests"
-task :default => :test
+YARD::Rake::YardocTask.new(:doc) do |t|
+  t.files = Dir["lib/**/*.rb"]
+  t.options = ["--fail-on-warning"]
+  t.stats_options = ["--list-undoc"]
+end
 
 desc "Run benchmarks"
 task :bench do
+  require_relative "test/bench"
   RubyMachOBenchmark.new.run
 end

--- a/lib/macho/exceptions.rb
+++ b/lib/macho/exceptions.rb
@@ -43,7 +43,7 @@ module MachO
 
   # Raised when a file's magic bytes are not valid Mach-O magic.
   class MagicError < NotAMachOError
-    # @param num [Integer] the unknown number
+    # @param magic [Integer] the unknown magic number
     def initialize(magic)
       super("Unrecognized Mach-O magic: 0x%02<magic>x" % { :magic => magic })
     end

--- a/ruby-macho.gemspec
+++ b/ruby-macho.gemspec
@@ -5,14 +5,18 @@ require "#{File.dirname(__FILE__)}/lib/macho"
 Gem::Specification.new do |s|
   s.name = "ruby-macho"
   s.version = MachO::VERSION
-  s.summary = "ruby-macho - Mach-O file analyzer."
+  s.summary = "Inspect and modify Mach-O files in pure Ruby"
   s.description = "A library for viewing and manipulating Mach-O files in Ruby."
   s.authors = ["William Woodruff"]
   s.email = "william@yossarian.net"
-  s.files = Dir["LICENSE", "README.md", ".yardopts", "lib/**/*"]
+  s.files = Dir["lib/**/*.rb"] + %w[.yardopts CONTRIBUTING.md LICENSE README.md machostructure-dsl-docs.md]
   s.required_ruby_version = ">= 3.3"
   s.homepage = "https://github.com/Homebrew/ruby-macho"
   s.license = "MIT"
   s.metadata["rubygems_mfa_required"] = "true"
+  s.metadata["source_code_uri"] = "https://github.com/Homebrew/ruby-macho"
+  s.metadata["bug_tracker_uri"] = "https://github.com/Homebrew/ruby-macho/issues"
+  s.metadata["documentation_uri"] = "https://www.rubydoc.info/gems/ruby-macho"
+  s.metadata["changelog_uri"] = "https://github.com/Homebrew/ruby-macho/releases"
   s.metadata["funding_uri"] = "https://github.com/sponsors/Homebrew"
 end

--- a/run-tests
+++ b/run-tests
@@ -20,24 +20,11 @@ which bundle > /dev/null 2>&1 \
 # Setup required Gems for testing.
 echo ">> Checking if required Gems are installed and installing missing Gems."
 if ! bundle check ; then
-  ensure bundle install --path vendor/bundle
+  ensure bundle config set --local path vendor/bundle
+  ensure bundle install
 fi
 echo
 
-# Run rubocop.
-echo ">> Running style enforcement."
-bundle exec rubocop -DES lib/
-result="$?"
-echo
-
-echo ">> Done: ${result}."
-
-# Run the test suite.
-echo ">> Running test suite."
-bundle exec rake test
-result="$?"
-echo
-
-# Be done and return result of test suite.
-echo ">> Done: ${result}."
-exit "${result}"
+# Run the repository-owned checks.
+echo ">> Running repository checks."
+exec bundle exec rake

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -4,8 +4,22 @@
 if ENV["CI"]
   require "simplecov"
   require "simplecov-cobertura"
-  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
-  SimpleCov.start
+  all_test_files = Dir[File.join(__dir__, "test_*.rb")].map { |path| File.expand_path(path) }.sort
+  selected_test_files = if File.basename($PROGRAM_NAME).start_with?("test_")
+    [File.expand_path($PROGRAM_NAME)]
+  else
+    ARGV.grep(/test_.*\.rb\z/).map { |path| File.expand_path(path) }.sort
+  end
+  filtered = ARGV.any? { |argument| argument.match?(/\A(?:-[nei]|--(?:name|exclude|include)(?:=|\z))/) }
+
+  SimpleCov.command_name "Minitest"
+  SimpleCov.start do
+    formatter SimpleCov::Formatter::CoberturaFormatter
+    cover "lib/**/*.rb"
+    enable_coverage :branch
+    minimum_coverage :line => 94, :branch => 70 if !filtered && selected_test_files == all_test_files
+    skip "/test/"
+  end
 end
 
 require "digest/sha1"
@@ -16,7 +30,7 @@ require "tempfile"
 require "macho"
 
 module Helpers
-  OTOOL_RX = /\t(.*) \(compatibility version (?:\d+\.)*\d+, current version (?:\d+\.)*\d+\)/.freeze
+  OTOOL_RX = /\t(.*) \(compatibility version (?:\d+\.)*\d+, current version (?:\d+\.)*\d+\)/
 
   # architectures used in testing 32-bit single-arch binaries
   SINGLE_32_ARCHES = %i[
@@ -51,7 +65,7 @@ module Helpers
     FileUtils.rm_f(file)
   end
 
-  def equal_sha1_hashes(file1, file2)
+  def equal_sha1_hashes?(file1, file2)
     digest1 = Digest::SHA1.file(file1).to_s
     digest2 = Digest::SHA1.file(file2).to_s
 

--- a/test/test_fat.rb
+++ b/test/test_fat.rb
@@ -332,7 +332,7 @@ class FatFileTest < Minitest::Test
 
       file.write(actual)
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::FatFile.new(actual)
       exp = MachO::FatFile.new(expected)
@@ -369,7 +369,7 @@ class FatFileTest < Minitest::Test
 
       file.write(actual)
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::FatFile.new(actual)
       exp = MachO::FatFile.new(expected)
@@ -422,7 +422,7 @@ class FatFileTest < Minitest::Test
 
       file.write(actual)
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::FatFile.new(actual)
       exp = MachO::FatFile.new(expected)
@@ -463,7 +463,7 @@ class FatFileTest < Minitest::Test
       assert_operator modified.rpaths.size, :<, orig_npaths
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end
@@ -494,7 +494,7 @@ class FatFileTest < Minitest::Test
       assert_includes modified.rpaths, "/foo/bar/baz"
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -113,6 +113,7 @@ class MachOFileTest < Minitest::Test
       end
     end
   end
+
   def test_load_commands
     filenames = SINGLE_ARCHES.map { |a| fixture(a, "hello.bin") }
 
@@ -431,7 +432,7 @@ class MachOFileTest < Minitest::Test
 
       file.write(actual)
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::MachOFile.new(actual)
       exp = MachO::MachOFile.new(expected)
@@ -471,7 +472,7 @@ class MachOFileTest < Minitest::Test
 
       file.write(actual)
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::MachOFile.new(actual)
       exp = MachO::MachOFile.new(expected)
@@ -546,7 +547,7 @@ class MachOFileTest < Minitest::Test
 
       file.write(actual)
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::MachOFile.new(actual)
       exp = MachO::MachOFile.new(expected)
@@ -605,7 +606,7 @@ class MachOFileTest < Minitest::Test
       assert_operator modified.rpaths.size, :<, orig_npaths
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end
@@ -648,7 +649,7 @@ class MachOFileTest < Minitest::Test
       assert_operator modified.rpaths.size, :<, orig_npaths
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end
@@ -691,7 +692,7 @@ class MachOFileTest < Minitest::Test
       assert_operator modified.rpaths.size, :<, orig_npaths
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end
@@ -728,7 +729,7 @@ class MachOFileTest < Minitest::Test
       assert_includes modified.rpaths, "/foo/bar/baz"
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end

--- a/test/test_tools.rb
+++ b/test/test_tools.rb
@@ -40,7 +40,7 @@ class MachOToolsTest < Minitest::Test
       FileUtils.cp filename, actual
       MachO::Tools.change_dylib_id(actual, "test")
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::MachOFile.new(actual)
       exp = MachO::MachOFile.new(expected)
@@ -64,7 +64,7 @@ class MachOToolsTest < Minitest::Test
       FileUtils.cp filename, actual
       MachO::Tools.change_dylib_id(actual, "test")
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::FatFile.new(actual)
       exp = MachO::FatFile.new(expected)
@@ -89,7 +89,7 @@ class MachOToolsTest < Minitest::Test
       oldname = MachO::Tools.dylibs(actual).first
       MachO::Tools.change_install_name(actual, oldname, "test")
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::MachOFile.new(actual)
       exp = MachO::MachOFile.new(expected)
@@ -114,7 +114,7 @@ class MachOToolsTest < Minitest::Test
       oldname = MachO::Tools.dylibs(actual).first
       MachO::Tools.change_install_name(actual, oldname, "test")
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       act = MachO::FatFile.new(actual)
       exp = MachO::FatFile.new(expected)
@@ -138,7 +138,7 @@ class MachOToolsTest < Minitest::Test
       FileUtils.cp filename, actual
       MachO::Tools.change_rpath(actual, "made_up_path", "/usr/lib")
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       file = MachO::MachOFile.new(filename)
       act = MachO::MachOFile.new(actual)
@@ -168,7 +168,7 @@ class MachOToolsTest < Minitest::Test
       FileUtils.cp filename, actual
       MachO::Tools.change_rpath(actual, "made_up_path", "/usr/lib")
 
-      assert equal_sha1_hashes(actual, expected)
+      assert equal_sha1_hashes?(actual, expected)
 
       file = MachO::FatFile.new(filename)
       act = MachO::FatFile.new(actual)
@@ -206,7 +206,7 @@ class MachOToolsTest < Minitest::Test
       assert_includes modified.rpaths, "/foo/bar/baz"
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end
@@ -229,7 +229,7 @@ class MachOToolsTest < Minitest::Test
       assert_includes modified.rpaths, "/foo/bar/baz"
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end
@@ -255,7 +255,7 @@ class MachOToolsTest < Minitest::Test
       refute_includes modified.rpaths, "made_up_path"
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end
@@ -279,7 +279,7 @@ class MachOToolsTest < Minitest::Test
       refute_includes modified.rpaths, "made_up_path"
     end
   ensure
-    groups.each do |_, actual|
+    groups.each do |(_filename, actual)|
       delete_if_exists(actual)
     end
   end


### PR DESCRIPTION
Consolidates the repository checks behind `bundle exec rake` so CI, the release workflow, and local runs all execute the same gate: RuboCop over the whole repository, the test suite, YARD with `--fail-on-warning`, and a smoke test that loads the packaged gem from a temporary directory.

Coverage minimums (94% line, 70% branch) are enforced in CI, but only for complete, unfiltered suites, so focused runs like `bundle exec ruby -Ilib -Itest test/test_macho.rb` do not fail on coverage.

Releases now verify that the tag matches the gem version and that the version is not already published before publishing.

Also fixes the `run-tests` bootstrap, which used `bundle install --path` — removed in Bundler 4 — and restricts the packaged gem to Ruby sources and documentation.

Verified locally on Ruby 3.3.12, 3.4.10, and 4.0.6.