### PR TITLE
Validate ntools and nhints against cmdsize and file bounds

### DIFF
--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -1254,15 +1254,26 @@ module MachO
       # A representation of the tool versions exposed
       # by a {BuildVersionCommand} (`LC_BUILD_VERSION`).
       class ToolEntries
+        TOOL_BYTESIZE = 8
+        UINT32S_PER_TOOL = 2
+
         # @return [Array<Tool>] all tools
         attr_reader :tools
 
         # @param view [MachO::MachOView] the view into the current Mach-O
         # @param ntools [Integer] the number of tools
+        # @param cmdsize [Integer] the size of the load command
         # @api private
-        def initialize(view, ntools)
-          format = Utils.specialize_format("L=#{ntools * 2}", view.endianness)
-          raw_table = view.raw_data[view.offset + 24, ntools * 8]
+        def initialize(view, ntools, cmdsize)
+          command_bytesize = BuildVersionCommand.bytesize
+          length = ntools * TOOL_BYTESIZE
+          offset = view.offset + command_bytesize
+
+          available = view.raw_data.bytesize - offset
+          raise LoadCommandSizeError, cmdsize if length > available || command_bytesize + length > cmdsize
+
+          format = Utils.specialize_format("L=#{ntools * UINT32S_PER_TOOL}", view.endianness)
+          raw_table = view.raw_data[offset, length]
           blobs = raw_table.unpack(format).each_slice(2).to_a
 
           @tools = blobs.map { |b| Tool.new(*b) }

--- a/lib/macho/load_commands.rb
+++ b/lib/macho/load_commands.rb
@@ -985,6 +985,8 @@ module MachO
       # A representation of the two-level namespace lookup hints table exposed
       # by a {TwolevelHintsCommand} (`LC_TWOLEVEL_HINTS`).
       class TwolevelHintsTable
+        HINT_BYTESIZE = 4
+
         # @return [Array<TwolevelHint>] all hints in the table
         attr_reader :hints
 
@@ -993,8 +995,12 @@ module MachO
         # @param nhints [Integer] the number of two-level hints in the table
         # @api private
         def initialize(view, htoffset, nhints)
+          length = nhints * HINT_BYTESIZE
+          available = view.raw_data.bytesize - htoffset
+          raise LoadCommandSizeError, length if length > available
+
           format = Utils.specialize_format("L=#{nhints}", view.endianness)
-          raw_table = view.raw_data[htoffset, nhints * 4]
+          raw_table = view.raw_data[htoffset, length]
           blobs = raw_table.unpack(format)
 
           @hints = blobs.map { |b| TwolevelHint.new(b) }

--- a/lib/macho/structure.rb
+++ b/lib/macho/structure.rb
@@ -212,7 +212,7 @@ module MachO
         when :tool_entries
           define_method(name) do
             instance_variable_defined?("@#{name}") ||
-              instance_variable_set("@#{name}", LoadCommands::BuildVersionCommand::ToolEntries.new(view, @values[idx]))
+              instance_variable_set("@#{name}", LoadCommands::BuildVersionCommand::ToolEntries.new(view, @values[idx], cmdsize))
 
             instance_variable_get("@#{name}")
           end

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -122,6 +122,30 @@ class MachOFileTest < Minitest::Test
     end
   end
 
+  def test_twolevel_hints_with_table_beyond_file
+    assert_raises MachO::LoadCommandSizeError do
+      twolevel_hints_command(1).table
+    end
+  end
+
+  def test_twolevel_hints_with_empty_table
+    assert_empty twolevel_hints_command(0).table.hints
+  end
+
+  def test_twolevel_hints_with_table_ending_at_file_end
+    command = twolevel_hints_command(1, [0x01000002].pack("L<"))
+
+    hint = command.table.hints.first
+    assert_equal 1, hint.isub_image
+    assert_equal 2, hint.itoc
+  end
+
+  def test_twolevel_hints_with_maximum_count
+    assert_raises MachO::LoadCommandSizeError do
+      twolevel_hints_command(0xFFFFFFFF).table
+    end
+  end
+
   def test_rpath_command
     assert_equal ["/usr/lib"], MachO::MachOFile.new(fixture(:yaml2obj, "rpath.macho")).rpaths
   end
@@ -840,6 +864,20 @@ class MachOFileTest < Minitest::Test
   end
 
   private
+
+  def twolevel_hints_command(nhints, table = "")
+    bin = File.binread(fixture(:yaml2obj, "build-version.macho")) + table
+    file = MachO::MachOFile.new_from_bin(bin)
+    format = file.endianness == :little ? "L<" : "L>"
+    offset = file.header.class.bytesize
+    htoffset = bin.bytesize - table.bytesize
+    bin[offset, 4] = [MachO::LoadCommands::LOAD_COMMAND_CONSTANTS[:LC_TWOLEVEL_HINTS]].pack(format)
+    bin[offset + 4, 4] = [MachO::LoadCommands::TwolevelHintsCommand.bytesize].pack(format)
+    bin[offset + 8, 4] = [htoffset].pack(format)
+    bin[offset + 12, 4] = [nhints].pack(format)
+
+    MachO::MachOFile.new_from_bin(bin)[:LC_TWOLEVEL_HINTS].first
+  end
 
   def assert_segment_sections_exceed_cmdsize(arch, command_type)
     bin = File.binread(fixture(arch, "hello.bin"))

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -96,6 +96,32 @@ class MachOFileTest < Minitest::Test
     assert_equal 1, command.tool_entries.tools.size
   end
 
+  def test_build_version_with_too_many_tools
+    assert_build_version_tools_exceed_cmdsize(:yaml2obj, "build-version.macho")
+  end
+
+  def test_build_version_tool_entries_exceed_command_boundary
+    bin = File.binread(fixture(:yaml2obj, "build-version.macho"))
+
+    # Increase sizeofcmds by 8 (from 32 to 40) so the load command region
+    # includes 8 extra bytes after LC_BUILD_VERSION
+    bin[20, 4] = [40].pack("L<")
+
+    # Set ntools to 2 (original is 1). This would require 24 + 2*8 = 40 bytes
+    # within the command, but cmdsize is only 32.
+    bin[52, 4] = [2].pack("L<")
+
+    # Append 8 bytes of zero data (simulating an unrelated tool entry)
+    bin << ("\x00" * 8)
+
+    file = MachO::MachOFile.new_from_bin(bin)
+    command = file[:LC_BUILD_VERSION].first
+
+    assert_raises MachO::LoadCommandSizeError do
+      command.tool_entries.tools
+    end
+  end
+
   def test_rpath_command
     assert_equal ["/usr/lib"], MachO::MachOFile.new(fixture(:yaml2obj, "rpath.macho")).rpaths
   end
@@ -832,6 +858,22 @@ class MachOFileTest < Minitest::Test
 
     assert_raises MachO::LoadCommandSizeError do
       segment.sections
+    end
+  end
+
+  def assert_build_version_tools_exceed_cmdsize(arch, fixture_name)
+    bin = File.binread(fixture(arch, fixture_name))
+    file = MachO::MachOFile.new_from_bin(bin)
+    command = file[:LC_BUILD_VERSION].first
+
+    ntools = ((command.cmdsize - command.class.bytesize) / 8) + 1
+    ntools_offset = command.view.offset + 20
+    bin[ntools_offset, 4] = [ntools].pack(file.endianness == :little ? "L<" : "L>")
+
+    command = MachO::MachOFile.new_from_bin(bin)[:LC_BUILD_VERSION].first
+
+    assert_raises MachO::LoadCommandSizeError do
+      command.tool_entries.tools
     end
   end
 end


### PR DESCRIPTION
Follow-up on review findings mentioned in #1026, which found that a similar count-controlled allocation pattern exists for `LC_BUILD_VERSION#ntools` and `LC_TWOLEVEL_HINTS#nhints`. 