### PR TITLE
Preserve dylib use-command flags when renaming

### DIFF
--- a/lib/macho/macho_file.rb
+++ b/lib/macho/macho_file.rb
@@ -344,10 +344,10 @@ module MachO
       old_lc = dylib_load_commands.find { |d| d.name.to_s == old_name }
       raise DylibUnknownError, old_name if old_lc.nil?
 
-      new_lc = LoadCommands::LoadCommand.create(old_lc.type, new_name,
-                                                old_lc.timestamp,
-                                                old_lc.current_version,
-                                                old_lc.compatibility_version)
+      args = [new_name, old_lc.timestamp, old_lc.current_version,
+              old_lc.compatibility_version]
+      args << old_lc.flags if old_lc.is_a?(LoadCommands::DylibUseCommand)
+      new_lc = LoadCommands::LoadCommand.create(old_lc.type, *args)
 
       replace_command(old_lc, new_lc)
     end

--- a/test/test_macho.rb
+++ b/test/test_macho.rb
@@ -552,6 +552,28 @@ class MachOFileTest < Minitest::Test
     assert_equal old_dylib_types, new_dylib_types
   end
 
+  def test_change_install_name_preserves_dylib_use_flags
+    file = MachO::MachOFile.new(fixture(:x86_64, "dylib_use_command-weak-delay.bin"))
+    old_lc = file.dylib_load_commands.find do |lc|
+      lc.is_a?(MachO::LoadCommands::DylibUseCommand)
+    end
+
+    assert_equal 9, old_lc.flags
+    assert old_lc.flag?(:DYLIB_USE_WEAK_LINK)
+    assert old_lc.flag?(:DYLIB_USE_DELAYED_INIT)
+
+    file.change_install_name(old_lc.name.to_s, "new.dylib")
+
+    new_lc = file.dylib_load_commands.find { |lc| lc.name.to_s == "new.dylib" }
+    assert_instance_of MachO::LoadCommands::DylibUseCommand, new_lc
+    assert_equal old_lc.timestamp, new_lc.timestamp
+    assert_equal old_lc.current_version, new_lc.current_version
+    assert_equal old_lc.compatibility_version, new_lc.compatibility_version
+    assert_equal old_lc.flags, new_lc.flags
+    assert new_lc.flag?(:DYLIB_USE_WEAK_LINK)
+    assert new_lc.flag?(:DYLIB_USE_DELAYED_INIT)
+  end
+
   def test_get_rpaths
     filenames = SINGLE_ARCHES.map { |a| fixture(a, "hello.bin") }
 


### PR DESCRIPTION
- Preserve `LC_DYLIB_USE_COMMAND` flags during dylib renames.
- Keep the original dylib use-command type instead of converting it to `LC_LOAD_DYLIB`.
- Add regression coverage for delayed-initialization and weak-link flags.